### PR TITLE
Screen Refresh

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/ExamActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ExamActivity.java
@@ -132,9 +132,10 @@ public class ExamActivity extends FragmentActivity implements LoaderManager.Load
                 getSupportFragmentManager().beginTransaction()
                         .replace(R.id.fragment_container, attemptFragment).commitAllowingStateLoss();
             } else {
-                //Show Start Exam Activity
-                Intent intent = new Intent(this, MainActivity.class);
-                intent.putExtra("currentItem", "2");
+                //Show Review when end button pressed
+                Intent intent = new Intent(this.getApplicationContext(), ReviewActivity.class);
+                intent.putExtra("exam", exam);
+                intent.putExtra("attempt", attempt);
                 startActivity(intent);
                 finish();
             }

--- a/app/src/main/java/in/testpress/testpress/ui/ReviewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ReviewActivity.java
@@ -57,15 +57,10 @@ public class ReviewActivity extends TestpressFragmentActivity {
 
     @Override
     public void onBackPressed() {
-        ActivityManager manager = (ActivityManager) getSystemService( ACTIVITY_SERVICE );
-        List<ActivityManager.RunningTaskInfo> taskList = manager.getRunningTasks(10);
-        if(taskList.get(0).numActivities == 1 && taskList.get(0).topActivity.getClassName().equals(this.getClass().getName())) {
+        //onBackPressed go to history
             Intent intent = new Intent(ReviewActivity.this, MainActivity.class);
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
             intent.putExtra("currentItem", "2");
             startActivity(intent);
             finish();
-        }
-        else super.onBackPressed();
     }
 }


### PR DESCRIPTION
After completing the exam / pausing the exam, when you go to history or available screen the screen does not gets refreshed automatically. Instead it shows the old screen. It might look confusing to the user. 

Once the exam has got completed / started the screen needs to get refreshed. 

Test cases: 
Start the exam (Dont end) -> Goto Home menu -> Now launch app. List has to be updated

Start the exam -> Pause the exam ->  Goto History / Available Screen.List has to be updated

Start the exam -> End the exam ->  Goto History / Available Screen.List has to be updated


