### PR TITLE
Integrate material dialog for all dialogs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,8 @@ dependencies {
     compile 'com.joanzapata.android:android-iconify:1.0.9'
     compile 'com.astuetz:pagerslidingtabstrip:1.0.1'
 
-
+    //Material Dialog
+    compile 'com.afollestad:material-dialogs:0.7.8.1'
     androidTestCompile 'junit:junit:4.11'
     androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
     androidTestCompile 'org.mockito:mockito-core:1.9.5'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.GET_TASKS" />
+    <uses-permission android:name="android.permission.RECEIVE_SMS" />
 
     <application
         android:name=".TestpressApplication"
@@ -86,8 +87,7 @@
 
         <activity
             android:name=".authenticator.CodeVerificationActivity"
-            android:label="Verify"
-            android:parentActivityName=".ui.MainActivity">
+            android:label="Verify">
         </activity>
 
     </application>

--- a/app/src/main/java/in/testpress/testpress/authenticator/NewUserRegistrationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/NewUserRegistrationActivity.java
@@ -105,13 +105,13 @@ public class NewUserRegistrationActivity extends Activity {
             public void onSuccess(final Boolean authSuccess) {
                 hideProgress();
                 Intent intent = new Intent(NewUserRegistrationActivity.this, CodeVerificationActivity.class);
+                intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 Bundle bundle = new Bundle();
                 bundle.putString("username", registrationSuccessResponse.getUsername());
                 bundle.putString("password", registrationSuccessResponse.getPassword());
                 intent.putExtras(bundle);
                 startActivity(intent);
                 finish();
-
             }
         }.execute();
     }

--- a/app/src/main/java/in/testpress/testpress/authenticator/NewUserRegistrationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/NewUserRegistrationActivity.java
@@ -13,6 +13,8 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.afollestad.materialdialogs.MaterialDialog;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,6 +46,7 @@ public class NewUserRegistrationActivity extends Activity {
     @InjectView(id.b_register) Button registerButton;
     private final TextWatcher watcher = validationTextWatcher();
     private RegistrationSuccessResponse registrationSuccessResponse;
+    private MaterialDialog progressDialog;
 
     @Override
     public void onCreate(Bundle bundle) {
@@ -69,7 +72,12 @@ public class NewUserRegistrationActivity extends Activity {
     }
 
     void postDetails(){
-        showProgress();
+        progressDialog = new MaterialDialog.Builder(this)
+                .title(R.string.loading)
+                .content(R.string.please_wait)
+                .widgetColorRes(R.color.primary)
+                .progress(true, 0)
+                .show();
         new SafeAsyncTask<Boolean>() {
             public Boolean call() throws Exception {
                 registrationSuccessResponse = testpressService.register(usernameText.getText().toString(), emailText.getText().toString(), passwordText.getText().toString(), phoneText.getText().toString());
@@ -98,12 +106,12 @@ public class NewUserRegistrationActivity extends Activity {
                         phoneText.requestFocus();
                     }
                 }
-                hideProgress();
+                progressDialog.dismiss();
             }
 
             @Override
             public void onSuccess(final Boolean authSuccess) {
-                hideProgress();
+                progressDialog.dismiss();
                 Intent intent = new Intent(NewUserRegistrationActivity.this, CodeVerificationActivity.class);
                 intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 Bundle bundle = new Bundle();
@@ -114,30 +122,6 @@ public class NewUserRegistrationActivity extends Activity {
                 finish();
             }
         }.execute();
-    }
-
-    /**
-     * Hide progress dialog
-     */
-    @SuppressWarnings("deprecation")
-    protected void hideProgress() {
-        dismissDialog(0);
-    }
-
-    /**
-     * Show progress dialog
-     */
-    @SuppressWarnings("deprecation")
-    protected void showProgress() {
-        showDialog(0);
-    }
-
-    @Override
-    protected Dialog onCreateDialog(int id) {
-        final ProgressDialog dialog = new ProgressDialog(this);
-        dialog.setMessage("Loading..");
-        dialog.setIndeterminate(true);
-        return dialog;
     }
 
     private TextWatcher validationTextWatcher() {

--- a/app/src/main/java/in/testpress/testpress/events/SmsReceivingEvent.java
+++ b/app/src/main/java/in/testpress/testpress/events/SmsReceivingEvent.java
@@ -1,0 +1,43 @@
+package in.testpress.testpress.events;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.telephony.SmsMessage;
+
+import in.testpress.testpress.authenticator.CodeVerificationActivity.Timer;
+
+public class SmsReceivingEvent extends BroadcastReceiver {
+    public String code;
+    private Timer timer;
+
+    public SmsReceivingEvent(Timer timer) {
+                this.timer = timer;
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        // Retrieves a map of extended data from the intent.
+        final Bundle bundle = intent.getExtras();
+        try {
+            if (bundle != null) {
+
+                final Object[] pdusObj = (Object[]) bundle.get("pdus");
+                SmsMessage currentMessage = SmsMessage.createFromPdu((byte[]) pdusObj[0]);
+                String senderNum = currentMessage.getDisplayOriginatingAddress();
+                if (senderNum.matches(".*TSTPRS")) { //check whether TSTPRS present in senderAddress
+                    String smsContent = currentMessage.getDisplayMessageBody();
+                    //get the code from smsContent
+                    code = smsContent.replaceAll(".*(?<=Thank you for registering at Testpress.in. Your authorization code is )([^\n]*)(?=.).*", "$1");
+                    timer.cancel();
+                    timer.onFinish();
+                }
+            } // bundle is null
+        } catch (Exception e) {
+            timer.cancel();
+            timer.onFinish();
+        }
+    }
+}
+

--- a/app/src/main/java/in/testpress/testpress/ui/AttemptsListActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/AttemptsListActivity.java
@@ -3,6 +3,7 @@ package in.testpress.testpress.ui;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
+import android.support.v7.widget.Toolbar;
 
 import in.testpress.testpress.R;
 import in.testpress.testpress.core.Constants;
@@ -13,10 +14,11 @@ public class AttemptsListActivity extends TestpressFragmentActivity {
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
-        setContentView(R.layout.activity_review);
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_review);
         AttemptsListFragment attemptsListFragment = new AttemptsListFragment();
         Bundle bundle = getIntent().getExtras();
+        Toolbar toolbar = getActionBarToolbar();
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setHomeButtonEnabled(true);
         Exam exam = bundle.getParcelable("exam");
@@ -24,5 +26,15 @@ public class AttemptsListActivity extends TestpressFragmentActivity {
         attemptsListFragment.setArguments(bundle);
         getSupportFragmentManager().beginTransaction()
                 .replace(R.id.fragment_container, attemptsListFragment).commitAllowingStateLoss();
+    }
+
+    public Toolbar getActionBarToolbar() {
+        if (mActionBarToolbar == null) {
+            mActionBarToolbar = (Toolbar) findViewById(R.id.toolbar_actionbar);
+            if (mActionBarToolbar != null) {
+                setSupportActionBar(mActionBarToolbar);
+            }
+        }
+        return mActionBarToolbar;
     }
 }

--- a/app/src/main/java/in/testpress/testpress/ui/ItemListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ItemListFragment.java
@@ -2,6 +2,8 @@
 package in.testpress.testpress.ui;
 
 import android.app.Activity;
+import android.graphics.Color;
+import android.graphics.PorterDuff;
 import android.os.Bundle;
 
 import android.support.v4.app.Fragment;
@@ -124,6 +126,7 @@ public abstract class ItemListFragment<E> extends Fragment
             }
         });
         progressBar = (ProgressBar) view.findViewById(id.pb_loading);
+        progressBar.getIndeterminateDrawable().setColorFilter(getResources().getColor(R.color.primary), PorterDuff.Mode.SRC_IN);
 
         emptyView = (TextView) view.findViewById(id.empty);
 

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -51,17 +51,15 @@ public class MainActivity extends TestpressFragmentActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         supportRequestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
+        // View injection with Butterknife
+        ButterKnife.inject(this);
+        super.onCreate(savedInstanceState);
 
         if(isTablet()) {
             setContentView(R.layout.main_activity_tablet);
         } else {
             setContentView(R.layout.main_activity);
         }
-
-        // View injection with Butterknife
-        ButterKnife.inject(this);
-
-        super.onCreate(savedInstanceState);
 
         //checkAuth();
         checkUpdate();

--- a/app/src/main/java/in/testpress/testpress/ui/ReviewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ReviewActivity.java
@@ -4,6 +4,7 @@ import android.app.ActivityManager;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
+import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
 
@@ -25,8 +26,10 @@ public class ReviewActivity extends TestpressFragmentActivity {
 
     @Override
     public void onCreate(final Bundle savedInstanceState) {
-        setContentView(R.layout.activity_review);
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_review);
+        Toolbar toolbar = getActionBarToolbar();
+        toolbar.setTitle("Review");
         Injector.inject(this);
         final Intent intent = getIntent();
         Bundle bundle = intent.getExtras();

--- a/app/src/main/java/in/testpress/testpress/ui/TestpressFragmentActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/TestpressFragmentActivity.java
@@ -33,11 +33,6 @@ public class TestpressFragmentActivity extends ActionBarActivity {
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Injector.inject(this);
-        Toolbar toolbar = getActionBarToolbar();
-        toolbar.setBackgroundResource(R.color.primary);
-        getSupportActionBar().setDisplayShowCustomEnabled(true);
-        getSupportActionBar().setDisplayShowTitleEnabled(true);
-        getSupportActionBar().setHomeButtonEnabled(true);
     }
 
     public Toolbar getActionBarToolbar() {
@@ -55,6 +50,10 @@ public class TestpressFragmentActivity extends ActionBarActivity {
         super.setContentView(layoutResId);
 
         ButterKnife.inject(this);
+        Toolbar toolbar = getActionBarToolbar();
+        getSupportActionBar().setDisplayShowCustomEnabled(true);
+        getSupportActionBar().setDisplayShowTitleEnabled(true);
+        getSupportActionBar().setHomeButtonEnabled(true);
     }
 
     @Override

--- a/app/src/main/res/layout/item_list.xml
+++ b/app/src/main/res/layout/item_list.xml
@@ -16,8 +16,6 @@
         android:layout_height="64dp"
         android:id="@+id/pb_loading"
         android:indeterminate="true"
-        android:indeterminateTint="@color/primary"
-        android:indeterminateTintMode="src_in"
         android:layout_centerInParent="true" />
 
     <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,7 +52,8 @@
     <string name="verify">Verify</string>
     <string name="label_ask_code">Enter the code sent via sms</string>
     <string name="verify_code">Verify Code</string>
-    <string name="message_verifying">Verifying…</string>
+    <string name="message_verifying">Verifying code</string>
+    <string name="message_receiving_code">Trying to receive code automatically</string>
     <string name="label_fill_all_details">*Please fill all details</string>
     <string name="register">Register</string>
     <string name="message_signing_in">Signing in…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,8 +36,12 @@
     <string name="paused">Paused</string>
     <string name="end">End</string>
     <string name="cancel">Cancel</string>
-    <string name="pause_message">Do you want to <b>Pause</b> exam?</string>
-    <string name="end_message">Do you want to <b>End</b> exam?</string>
+    <string name="pause_message">Do you want to Pause the exam?</string>
+    <string name="pause_content">You can pause the exam &amp; resume later before end date</string>
+    <string name="end_message">Do you want to End the exam?</string>
+    <string name="loading">Loading</string>
+    <string name="please_wait">Please Wait...</string>
+    <string name="ok">OK</string>
     <string name="authentication_failed">Authentication failed</string>
     <string name="no_internet">No active internet connection</string>
 

--- a/app/src/main/res/values/theme.xml
+++ b/app/src/main/res/values/theme.xml
@@ -8,7 +8,7 @@
         <item name="colorPrimary">@color/primary</item>
         <!--<item name="colorPrimaryDark">@color/theme_primary_dark</item>-->
         <!--<item name="colorAccent">@color/theme_accent_2</item>-->
-
+        <item name="windowNoTitle">true</item>
         <!--<item name="android:textColorLink">@color/theme_accent_2</item>-->
 
     </style>


### PR DESCRIPTION
Instead of default dialog, we need to use https://github.com/afollestad/material-dialogs for a consistent UI. Custom alert dialogs in exam pause, end etc also should be replaced with this.