### PR TITLE
RegisterDevice & checkUpdate only when app starts

### DIFF
--- a/app/src/main/java/in/testpress/testpress/TestpressApplication.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressApplication.java
@@ -18,6 +18,8 @@ import in.testpress.testpress.models.DaoSession;
 public class TestpressApplication extends Application {
     private static TestpressApplication instance;
     public DaoSession daoSession;
+    boolean appInitiated;
+    boolean hasUserAuthenticated;
 
     /**
      * Create main application
@@ -48,11 +50,26 @@ public class TestpressApplication extends Application {
         SQLiteDatabase db = helper.getWritableDatabase();
         DaoMaster daoMaster = new DaoMaster(db);
         daoSession = daoMaster.newSession();
-
     }
 
     public DaoSession getDaoSession() {
         return daoSession;
+    }
+
+    public boolean isAppInitiated() {
+        return appInitiated;
+    }
+
+    public void setAppInitiated(boolean appInitiated) {
+        this.appInitiated = appInitiated;
+    }
+
+    public boolean hasUserAuthenticated() {
+        return hasUserAuthenticated;
+    }
+
+    public void setUserAuthenticated(boolean hasUserAuthenticated) {
+        this.hasUserAuthenticated = hasUserAuthenticated;
     }
 
     public static void initImageLoader(Context context) {

--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -2,16 +2,12 @@ package in.testpress.testpress;
 
 import android.accounts.AccountsException;
 import android.app.Activity;
-import android.content.Intent;
 
 import java.io.IOException;
 
 import in.testpress.testpress.authenticator.ApiKeyProvider;
-import in.testpress.testpress.authenticator.LogoutService;
 import in.testpress.testpress.core.TestpressService;
-import in.testpress.testpress.models.DaoSession;
-import in.testpress.testpress.models.PostDao;
-import in.testpress.testpress.ui.MainActivity;
+
 import retrofit.RestAdapter;
 
 public class TestpressServiceProvider {
@@ -45,27 +41,5 @@ public class TestpressServiceProvider {
 
         // TODO: See how that affects the testpress service.
         return new TestpressService(restAdapter, authToken);
-    }
-
-    public void handleForbidden(final Activity activity, TestpressServiceProvider serviceProvider, LogoutService logoutService) {
-        serviceProvider.invalidateAuthToken();
-        DaoSession daoSession = ((TestpressApplication) activity.getApplicationContext()).getDaoSession();
-        PostDao postDao = daoSession.getPostDao();
-        postDao.deleteAll();
-        daoSession.clear();
-        logoutService.logout(new Runnable() {
-            @Override
-            public void run() {
-                Intent intent;
-                if(activity.getClass() == MainActivity.class) {
-                    intent = activity.getIntent();
-                } else {
-                    intent = new Intent(activity, MainActivity.class);
-                    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                }
-                activity.startActivity(intent);
-                activity.finish();
-            }
-        });
     }
 }

--- a/app/src/main/java/in/testpress/testpress/authenticator/LogoutService.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LogoutService.java
@@ -3,9 +3,21 @@ package in.testpress.testpress.authenticator;
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.accounts.AccountManagerFuture;
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 
+import com.afollestad.materialdialogs.MaterialDialog;
+
+import in.testpress.testpress.R;
+import in.testpress.testpress.TestpressApplication;
+import in.testpress.testpress.TestpressServiceProvider;
 import in.testpress.testpress.core.Constants;
+import in.testpress.testpress.models.DaoSession;
+import in.testpress.testpress.models.PostDao;
+import in.testpress.testpress.ui.MainActivity;
 import in.testpress.testpress.util.Ln;
 import in.testpress.testpress.util.SafeAsyncTask;
 
@@ -75,5 +87,38 @@ public class LogoutService {
 
             Ln.e(e.getCause(), "Logout failed.");
         }
+    }
+
+    public void logout(final Activity activity, TestpressServiceProvider serviceProvider, LogoutService logoutService) {
+        final MaterialDialog materialDialog = new MaterialDialog.Builder(activity)
+                .title(R.string.label_logging_out)
+                .content(R.string.please_wait)
+                .widgetColorRes(R.color.primary)
+                .progress(true, 0)
+                .show();
+        serviceProvider.invalidateAuthToken();
+        //set the user is unAuthenticated, to check the auth in MainActivity
+        ((TestpressApplication) activity.getApplicationContext()).setUserAuthenticated(false);
+        DaoSession daoSession = ((TestpressApplication) activity.getApplicationContext()).getDaoSession();
+        PostDao postDao = daoSession.getPostDao();
+        postDao.deleteAll();
+        daoSession.clear();
+        logoutService.logout(new Runnable() {
+            @Override
+            public void run() {
+                // Calling a checkAuth in MainActivity will force the service to look for a logged in user
+                // and when it finds none the user will be requested to log in again.
+                Intent intent;
+                if(activity.getClass() == MainActivity.class) {
+                    intent = activity.getIntent();
+                } else {
+                    intent = new Intent(activity, MainActivity.class);
+                }
+                intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
+                materialDialog.dismiss();
+                activity.finish();
+                activity.startActivity(intent);
+            }
+        });
     }
 }

--- a/app/src/main/java/in/testpress/testpress/core/Constants.java
+++ b/app/src/main/java/in/testpress/testpress/core/Constants.java
@@ -39,7 +39,7 @@ public final class Constants {
         /**
          * Base URL for all requests
          */
-        public static final String URL_BASE = "http://192.168.0.100:8000";
+        public static final String URL_BASE = "http://sandbox.testpress.in";
 
         /**
          * Check Update url

--- a/app/src/main/java/in/testpress/testpress/ui/ExamsListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ExamsListFragment.java
@@ -215,7 +215,7 @@ public class ExamsListFragment extends PagedItemFragment<Exam> {
     @Override
     protected int getErrorMessage(Exception exception) {
         if((exception.getMessage() != null) && (exception.getMessage()).equals("403 FORBIDDEN")) {
-            serviceProvider.handleForbidden(getActivity(), serviceProvider, logoutService);
+            logoutService.logout(getActivity(), serviceProvider, logoutService);
             return R.string.authentication_failed;
         } else {
             setEmptyText(R.string.no_internet);

--- a/app/src/main/java/in/testpress/testpress/ui/OrderConfirmActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/OrderConfirmActivity.java
@@ -8,7 +8,6 @@ import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.KeyEvent;
-import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -89,7 +88,7 @@ public class OrderConfirmActivity extends TestpressFragmentActivity {
                 if(accounts.length != 0) {
                     return serviceProvider.getService(OrderConfirmActivity.this).order(Constants.Http.URL_USERS + accounts[0].name + "/", orderItems);
                 } else {
-                    serviceProvider.handleForbidden(OrderConfirmActivity.this, serviceProvider, logoutService);
+                    logoutService.logout(OrderConfirmActivity.this, serviceProvider, logoutService);
                     throw new Exception("No Account exist");
                 }
             }

--- a/app/src/main/java/in/testpress/testpress/ui/OrdersListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/OrdersListFragment.java
@@ -83,7 +83,7 @@ public class OrdersListFragment extends PagedItemFragment<Order> {
     @Override
     protected int getErrorMessage(Exception exception) {
         if((exception.getMessage() != null) && (exception.getMessage()).equals("403 FORBIDDEN")) {
-            serviceProvider.handleForbidden(getActivity(), serviceProvider, logoutService);
+            logoutService.logout(getActivity(), serviceProvider, logoutService);
             return R.string.authentication_failed;
         } else {
             setEmptyText(R.string.no_internet);

--- a/app/src/main/java/in/testpress/testpress/ui/PostActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PostActivity.java
@@ -114,15 +114,6 @@ public class PostActivity extends TestpressFragmentActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        if(item.getItemId() == android.R.id.home) {
-            onBackPressed();
-            return true;
-        }
-        return false;
-    }
-
-    @Override
     public void onBackPressed() {
         if(urlWithBase != null) {
             super.onBackPressed();

--- a/app/src/main/java/in/testpress/testpress/ui/PostsListActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PostsListActivity.java
@@ -28,15 +28,6 @@ public class PostsListActivity extends TestpressFragmentActivity {
     }
 
     @Override
-    public boolean onOptionsItemSelected(final MenuItem item) {
-        if(item.getItemId() == android.R.id.home) {
-            onBackPressed();
-            return true;
-        }
-        return false;
-    }
-
-    @Override
     public void onBackPressed() {
         if(fromPostDetail) {
             Intent intent = new Intent(this, MainActivity.class);

--- a/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
@@ -410,7 +410,7 @@ public class PostsListFragment extends Fragment implements
 
     protected int getErrorMessage(Exception exception) {
         if((exception.getMessage() != null) && (exception.getMessage()).equals("403 FORBIDDEN")) {
-            serviceProvider.handleForbidden(getActivity(), serviceProvider, logoutService);
+            logoutService.logout(getActivity(), serviceProvider, logoutService);
             return R.string.authentication_failed;
         } else if (exception.getCause() instanceof UnknownHostException) {
             emptyView.setText(R.string.no_internet);

--- a/app/src/main/java/in/testpress/testpress/ui/ProductListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ProductListFragment.java
@@ -93,7 +93,7 @@ public class ProductListFragment extends PagedItemFragment<Product> {
     @Override
     protected int getErrorMessage(Exception exception) {
         if((exception.getMessage() != null) && (exception.getMessage()).equals("403 FORBIDDEN")) {
-            serviceProvider.handleForbidden(getActivity(), serviceProvider, logoutService);
+            logoutService.logout(getActivity(), serviceProvider, logoutService);
             return R.string.authentication_failed;
         } else {
             setEmptyText(R.string.no_internet);


### PR DESCRIPTION
RegisterDevice, checkUpdate, checkAuth methods on MainActivity have to
be called only when app starts newly & not when MainActivity is started
by any another activity afterwards

Fixes #65