### PR TITLE
Fix bug in pagination

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/AttemptsListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/AttemptsListFragment.java
@@ -30,7 +30,6 @@ import in.testpress.testpress.util.Ln;
 public class AttemptsListFragment extends PagedItemFragment<Attempt> {
 
     Exam exam;
-    AttemptsPager pager;
     @Inject protected TestpressServiceProvider serviceProvider;
 
     @Override

--- a/app/src/main/java/in/testpress/testpress/ui/ExamsListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ExamsListFragment.java
@@ -34,7 +34,6 @@ import javax.inject.Inject;
 public class ExamsListFragment extends PagedItemFragment<Exam> {
 
     String subclass;
-    ExamPager pager;
     //List of courses got from the api. This is used to populate the spinner.
     ArrayList<String> courses = new ArrayList<String>();
     @Inject protected TestpressServiceProvider serviceProvider;

--- a/app/src/main/java/in/testpress/testpress/ui/OrdersListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/OrdersListFragment.java
@@ -27,7 +27,6 @@ public class OrdersListFragment extends PagedItemFragment<Order> {
 
     @Inject protected TestpressServiceProvider serviceProvider;
     @Inject protected LogoutService logoutService;
-    OrdersPager pager;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/in/testpress/testpress/ui/PagedItemFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PagedItemFragment.java
@@ -105,7 +105,7 @@ public abstract class PagedItemFragment<E> extends ItemListFragment<E>
 
     @Override
     protected void refreshWithProgress() {
-        pager.reset();
+        getPager().reset();
         pager = getPager();
 
         super.refreshWithProgress();

--- a/app/src/main/java/in/testpress/testpress/ui/ProductListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ProductListFragment.java
@@ -28,8 +28,6 @@ public class ProductListFragment extends PagedItemFragment<Product> {
     @Inject protected TestpressServiceProvider serviceProvider;
     @Inject protected LogoutService logoutService;
 
-    ProductsPager pager;
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         Injector.inject(this);

--- a/app/src/main/java/in/testpress/testpress/ui/ReviewQuestionsFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ReviewQuestionsFragment.java
@@ -30,7 +30,6 @@ public class ReviewQuestionsFragment extends PagedItemFragment<ReviewItem> {
     Attempt attempt;
     Exam exam;
     String filter;
-    ReviewQuestionsPager pager;
     @Inject protected TestpressServiceProvider serviceProvider;
 
     @Override


### PR DESCRIPTION
When initiating the pager variable, the extended class pager variable
only initializing & not the pager in PagedItemFragment. So, the usages
of that variable always giving null. Now the pager variable in extended
class is removed as it is need not. So, the PagedItemFragment pager is
initializing directly.