### PR TITLE
Add authorization header through OkHttpClient network interceptor

### DIFF
--- a/app/src/main/java/in/testpress/testpress/TestpressModule.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressModule.java
@@ -103,13 +103,13 @@ public class TestpressModule {
 //    }
 
     @Provides
-    TestpressService provideTestpressService(RestAdapter restAdapter) {
+    TestpressService provideTestpressService(RestAdapter.Builder restAdapter) {
         return new TestpressService(restAdapter);
     }
 
     @Singleton
     @Provides
-    TestpressServiceProvider provideTestpressServiceProvider(RestAdapter restAdapter, ApiKeyProvider apiKeyProvider) {
+    TestpressServiceProvider provideTestpressServiceProvider(RestAdapter.Builder restAdapter, ApiKeyProvider apiKeyProvider) {
         return new TestpressServiceProvider(restAdapter, apiKeyProvider);
     }
 
@@ -149,13 +149,12 @@ public class TestpressModule {
     }
 
     @Provides
-    RestAdapter provideRestAdapter(RestErrorHandler restErrorHandler, RestAdapterRequestInterceptor restRequestInterceptor, Gson gson) {
+    RestAdapter.Builder provideRestAdapter(RestErrorHandler restErrorHandler, RestAdapterRequestInterceptor restRequestInterceptor, Gson gson) {
         return new RestAdapter.Builder()
                 .setEndpoint(Constants.Http.URL_BASE)
                 .setErrorHandler(restErrorHandler)
                 .setRequestInterceptor(restRequestInterceptor)
                 .setLogLevel(RestAdapter.LogLevel.FULL)
-                .setConverter(new GsonConverter(gson))
-                .build();
+                .setConverter(new GsonConverter(gson));
     }
 }

--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -21,11 +21,11 @@ import in.testpress.testpress.util.GCMPreference;
 import retrofit.RestAdapter;
 
 public class TestpressServiceProvider {
-    private RestAdapter restAdapter;
+    private RestAdapter.Builder restAdapter;
     private ApiKeyProvider keyProvider;
     String authToken;
 
-    public TestpressServiceProvider(RestAdapter restAdapter, ApiKeyProvider keyProvider) {
+    public TestpressServiceProvider(RestAdapter.Builder restAdapter, ApiKeyProvider keyProvider) {
         this.restAdapter = restAdapter;
         this.keyProvider = keyProvider;
     }

--- a/app/src/main/java/in/testpress/testpress/core/AuthenticationService.java
+++ b/app/src/main/java/in/testpress/testpress/core/AuthenticationService.java
@@ -6,16 +6,11 @@ import in.testpress.testpress.models.AuthToken;
 import in.testpress.testpress.models.ProfileDetails;
 import in.testpress.testpress.models.RegistrationSuccessResponse;
 import in.testpress.testpress.models.Update;
-import retrofit.Callback;
 import retrofit.http.Body;
 import retrofit.http.EncodedPath;
-import retrofit.http.Field;
-import retrofit.http.FormUrlEncoded;
 import retrofit.http.GET;
-import retrofit.http.Header;
 import retrofit.http.POST;
 import retrofit.http.PUT;
-import retrofit.http.Query;
 
 public interface AuthenticationService {
 
@@ -39,8 +34,9 @@ public interface AuthenticationService {
     Update checkUpdate(@Body HashMap<String, String> arguments);
 
     @GET(Constants.Http.URL_PROFILE_DETAILS_FRAG)
-    ProfileDetails getProfileDetails(@Header("Authorization") String authorization);
+    ProfileDetails getProfileDetails();
 
     @PUT("/{updateUserUrlFrag}")
-    ProfileDetails updateUser(@EncodedPath("updateUserUrlFrag") String updateUserUrlFrag, @Body HashMap<String, Object> arguments, @Header("Authorization") String authorization);
+    ProfileDetails updateUser(@EncodedPath("updateUserUrlFrag") String updateUserUrlFrag,
+                              @Body HashMap<String, Object> arguments);
 }

--- a/app/src/main/java/in/testpress/testpress/core/DeviceService.java
+++ b/app/src/main/java/in/testpress/testpress/core/DeviceService.java
@@ -5,11 +5,10 @@ import java.util.HashMap;
 
 import in.testpress.testpress.models.Device;
 import retrofit.http.Body;
-import retrofit.http.Header;
 import retrofit.http.POST;
 
 public interface DeviceService {
 
     @POST(Constants.Http.URL_DEVICES_REGISTER_FRAG)
-    Device register(@Body HashMap<String, String> arguments,  @Header("Authorization") String authorization);
+    Device register(@Body HashMap<String, String> arguments);
 }

--- a/app/src/main/java/in/testpress/testpress/core/DocumentsService.java
+++ b/app/src/main/java/in/testpress/testpress/core/DocumentsService.java
@@ -6,17 +6,17 @@ import in.testpress.testpress.models.Notes;
 import in.testpress.testpress.models.TestpressApiResponse;
 
 import retrofit.http.GET;
-import retrofit.http.Header;
 import retrofit.http.Path;
 import retrofit.http.QueryMap;
 
 public interface DocumentsService {
 
     @GET("/{documents_url}")
-    TestpressApiResponse<Notes> getDocumentsList(@Path("documents_url") String urlFrag, @QueryMap Map<String, String> options, @Header("Authorization") String authorization);
+    TestpressApiResponse<Notes> getDocumentsList(@Path("documents_url") String urlFrag,
+                                                 @QueryMap Map<String, String> options);
 
     @GET("/" + Constants.Http.URL_DOCUMENTS_FRAG + "{slug}/download" )
-    Notes getDownloadUrl(@Path("slug") String urlFrag, @Header("Authorization") String authorization);
+    Notes getDownloadUrl(@Path("slug") String urlFrag);
 
 }
 

--- a/app/src/main/java/in/testpress/testpress/core/PostService.java
+++ b/app/src/main/java/in/testpress/testpress/core/PostService.java
@@ -17,14 +17,14 @@ public interface PostService {
     TestpressApiResponse<Post> getPosts(
             @EncodedPath("posts_url") String postUrl,
             @QueryMap Map<String, String> options,
-            @Header("Authorization") String authorization,
             @Header("If-Modified-Since") String latestModifiedDate
     );
 
     @GET("/" + Constants.Http.URL_POSTS_FRAG + "{post_url}")
-    Post getPostDetails(@EncodedPath("post_url") String postUrl, @QueryMap Map<String, Boolean> options, @Header("Authorization") String authorization);
+    Post getPostDetails(@EncodedPath("post_url") String postUrl, @QueryMap Map<String, Boolean> options);
 
     @GET("/{categories_url}")
-    TestpressApiResponse<Category> getCategories(@EncodedPath("categories_url") String categoriesUrl, @QueryMap Map<String, String> options, @Header("Authorization") String authorization);
+    TestpressApiResponse<Category> getCategories(@EncodedPath("categories_url") String categoriesUrl,
+                                                 @QueryMap Map<String, String> options);
 
 }

--- a/app/src/main/java/in/testpress/testpress/core/ProductService.java
+++ b/app/src/main/java/in/testpress/testpress/core/ProductService.java
@@ -10,7 +10,6 @@ import in.testpress.testpress.models.TestpressApiResponse;
 import retrofit.http.Body;
 import retrofit.http.EncodedPath;
 import retrofit.http.GET;
-import retrofit.http.Header;
 import retrofit.http.POST;
 import retrofit.http.PUT;
 import retrofit.http.QueryMap;
@@ -18,19 +17,21 @@ import retrofit.http.QueryMap;
 public interface ProductService {
 
     @GET("/{products_url}")
-    TestpressApiResponse<Product> getProducts(@EncodedPath("products_url") String productsUrl, @QueryMap Map<String, String> options);
+    TestpressApiResponse<Product> getProducts(@EncodedPath("products_url") String productsUrl,
+                                              @QueryMap Map<String, String> options);
 
     @GET("/{product_url}")
     ProductDetails getProductDetails(@EncodedPath("product_url") String productUrlFrag);
 
     @POST(Constants.Http.URL_ORDERS_FRAG)
-    Order order(@Body HashMap<String, Object> arguments, @Header("Authorization") String authorization);
+    Order order(@Body HashMap<String, Object> arguments);
 
     @PUT("/{confirmUrlFrag}")
-    Order orderConfirm(@EncodedPath("confirmUrlFrag") String confirmUrlFrag, @Body HashMap<String, Object> arguments, @Header("Authorization") String authorization);
+    Order orderConfirm(@EncodedPath("confirmUrlFrag") String confirmUrlFrag,
+                       @Body HashMap<String, Object> argumentsn);
 
     @GET("/{orders_url}")
-    TestpressApiResponse<Order> getOrders(@EncodedPath("orders_url") String ordersUrl, @Header("Authorization") String authorization);
+    TestpressApiResponse<Order> getOrders(@EncodedPath("orders_url") String ordersUrl);
 
 }
 

--- a/app/src/main/java/in/testpress/testpress/ui/PostActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PostActivity.java
@@ -114,7 +114,8 @@ public class PostActivity extends DeepLinkHandlerActivity {
                 }
                 Map<String, Boolean> queryParams = new LinkedHashMap<>();
                 queryParams.put("short_link", true);
-                return testpressService.getPostDetail(shortWebUrl.replace(Constants.Http.URL_BASE +"/p/", ""), queryParams);
+                Uri uri = Uri.parse(shortWebUrl);
+                return testpressService.getPostDetail(uri.getLastPathSegment(), queryParams);
             }
 
             @Override


### PR DESCRIPTION
- Authorization header is not sending in the redirecting network
requests. This is fixed by adding authorization header through
OkHttpClient network interceptor.

- Post detail url needs the short_link, which is parsed from the
shortWebUrl by removing the base url. It is now parsed independent of
base url.