### PR TITLE
Remove sms permission for registration.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ android {
 
         def host_url = json.testpress_site_subdomain + '.testpress.in'
         resValue "string", "host_url", host_url
-        buildConfigField "String", "BASE_URL", '"https://ded2702c.ngrok.io/"'  //'"https://' + host_url + '"'
+        buildConfigField "String", "BASE_URL", '"https://' + host_url + '"'
         resValue "string", "app_name", json.app_name
         resValue "string", "share_message", json.share_message
         resValue "string", "facebook_app_id", json.facebook_app_id

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ android {
 
         def host_url = json.testpress_site_subdomain + '.testpress.in'
         resValue "string", "host_url", host_url
-        buildConfigField "String", "BASE_URL", '"https://' + host_url + '"'
+        buildConfigField "String", "BASE_URL", '"https://ded2702c.ngrok.io/"'  //'"https://' + host_url + '"'
         resValue "string", "app_name", json.app_name
         resValue "string", "share_message", json.share_message
         resValue "string", "facebook_app_id", json.facebook_app_id

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.RECEIVE_SMS" />
 
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 

--- a/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
@@ -117,17 +117,10 @@ public class CodeVerificationActivity extends AppCompatActivity {
             welcomeText.setText("Waiting to automatically detect an sms sent to " + phoneNumber + "\nIf you get the verification code press Manually Verify");
             timer = new Timer();
             smsReceivingEvent = new SmsReceivingEvent(timer);
-//            packageManager = getBaseContext().getPackageManager();
-//            if (packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
             IntentFilter filter = new IntentFilter();
-//            filter.addAction("android.provider.Telephony.SMS_RECEIVED");
             filter.addAction(SmsRetriever.SMS_RETRIEVED_ACTION);
-            //Register SMS broadcast receiver
-            registerReceiver(smsReceivingEvent, filter); //start receiver
+            registerReceiver(smsReceivingEvent, filter); //Register SMS broadcast receiver
             timer.start(); // Start timer
-//            } else {
-//                timer.onFinish();
-//            }
         }
         verificationCodeText.addTextChangedListener(watcher);
         verificationCodeText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
@@ -186,10 +179,8 @@ public class CodeVerificationActivity extends AppCompatActivity {
         public void onFinish() {
             countText.setText("30s");
             progressBar.setProgress(30);
-//            if (packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
-//                unregisterReceiver(smsReceivingEvent); //end receiver
-//            }
             unregisterReceiver(smsReceivingEvent); //end receiver
+
             if (smsReceivingEvent.code  != null) { //checking smsReceivingEvent get the code or not
                 verificationCodeText.setText(smsReceivingEvent.code);
                 handleCodeVerification(); //verify code

--- a/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
@@ -27,12 +27,7 @@ import android.widget.TextView;
 import com.afollestad.materialdialogs.GravityEnum;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.gms.auth.api.phone.SmsRetriever;
-import com.google.android.gms.auth.api.phone.SmsRetrieverClient;
-import com.google.android.gms.tasks.OnFailureListener;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.android.gms.tasks.Task;
 
-import java.util.Timer;
 
 import java.io.IOException;
 import java.util.List;
@@ -107,7 +102,7 @@ public class CodeVerificationActivity extends AppCompatActivity {
         username = intent.getStringExtra("username");
         password = intent.getStringExtra("password");
         String phoneNumber = intent.getStringExtra("phoneNumber");
-        if (username == null) {
+        if(username == null){
             usernameText.setVisibility(View.VISIBLE);
             verificationCodeText.setVisibility(View.VISIBLE);
             verifyButton.setVisibility(View.VISIBLE);

--- a/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.provider.Settings;
+import android.support.annotation.NonNull;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -25,6 +26,13 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.GravityEnum;
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.gms.auth.api.phone.SmsRetriever;
+import com.google.android.gms.auth.api.phone.SmsRetrieverClient;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
+
+import java.util.Timer;
 
 import java.io.IOException;
 import java.util.List;
@@ -99,7 +107,7 @@ public class CodeVerificationActivity extends AppCompatActivity {
         username = intent.getStringExtra("username");
         password = intent.getStringExtra("password");
         String phoneNumber = intent.getStringExtra("phoneNumber");
-        if(username == null){
+        if (username == null) {
             usernameText.setVisibility(View.VISIBLE);
             verificationCodeText.setVisibility(View.VISIBLE);
             verifyButton.setVisibility(View.VISIBLE);
@@ -109,15 +117,17 @@ public class CodeVerificationActivity extends AppCompatActivity {
             welcomeText.setText("Waiting to automatically detect an sms sent to " + phoneNumber + "\nIf you get the verification code press Manually Verify");
             timer = new Timer();
             smsReceivingEvent = new SmsReceivingEvent(timer);
-            packageManager = getBaseContext().getPackageManager();
-            if (packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
-                IntentFilter filter = new IntentFilter();
-                filter.addAction("android.provider.Telephony.SMS_RECEIVED");
-                registerReceiver(smsReceivingEvent, filter); //start receiver
-                timer.start(); // Start timer
-            } else {
-                timer.onFinish();
-            }
+//            packageManager = getBaseContext().getPackageManager();
+//            if (packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
+            IntentFilter filter = new IntentFilter();
+//            filter.addAction("android.provider.Telephony.SMS_RECEIVED");
+            filter.addAction(SmsRetriever.SMS_RETRIEVED_ACTION);
+            //Register SMS broadcast receiver
+            registerReceiver(smsReceivingEvent, filter); //start receiver
+            timer.start(); // Start timer
+//            } else {
+//                timer.onFinish();
+//            }
         }
         verificationCodeText.addTextChangedListener(watcher);
         verificationCodeText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
@@ -176,9 +186,10 @@ public class CodeVerificationActivity extends AppCompatActivity {
         public void onFinish() {
             countText.setText("30s");
             progressBar.setProgress(30);
-            if (packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
-                unregisterReceiver(smsReceivingEvent); //end receiver
-            }
+//            if (packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
+//                unregisterReceiver(smsReceivingEvent); //end receiver
+//            }
+            unregisterReceiver(smsReceivingEvent); //end receiver
             if (smsReceivingEvent.code  != null) { //checking smsReceivingEvent get the code or not
                 verificationCodeText.setText(smsReceivingEvent.code);
                 handleCodeVerification(); //verify code

--- a/app/src/main/java/in/testpress/testpress/authenticator/RegisterActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/RegisterActivity.java
@@ -47,16 +47,13 @@ import in.testpress.testpress.models.RegistrationErrorDetails;
 import in.testpress.testpress.ui.TextWatcherAdapter;
 import in.testpress.testpress.util.InternetConnectivityChecker;
 import in.testpress.testpress.util.SafeAsyncTask;
-import in.testpress.util.PermissionsUtils;
 import retrofit.RetrofitError;
 
-//import static android.Manifest.permission.RECEIVE_SMS;
 import static android.view.inputmethod.EditorInfo.IME_ACTION_DONE;
 import static in.testpress.testpress.BuildConfig.BASE_URL;
 import static in.testpress.testpress.authenticator.LoginActivity.REQUEST_CODE_REGISTER_USER;
 import static in.testpress.testpress.authenticator.RegisterActivity.VerificationMethod.EMAIL;
 import static in.testpress.testpress.authenticator.RegisterActivity.VerificationMethod.MOBILE;
-//import static in.testpress.testpress.core.Constants.RequestCode.RECEIVE_SMS_PERMISSION_REQUEST_CODE;
 
 public class RegisterActivity extends AppCompatActivity {
 
@@ -76,7 +73,6 @@ public class RegisterActivity extends AppCompatActivity {
     private final TextWatcher watcher = validationTextWatcher();
     private RegistrationSuccessResponse registrationSuccessResponse;
     private MaterialDialog progressDialog;
-//    private PermissionsUtils permissionsUtils;
     private InternetConnectivityChecker internetConnectivityChecker = new InternetConnectivityChecker(this);
     private VerificationMethod verificationMethod;
     enum VerificationMethod { MOBILE, EMAIL }
@@ -101,8 +97,6 @@ public class RegisterActivity extends AppCompatActivity {
             // Never happen, just for a safety.
             finish();
         }
-//        String[] permissions = new String[] { RECEIVE_SMS };
-//        permissionsUtils = new PermissionsUtils(this, registerLayout, permissions);
 
         confirmPasswordText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             public boolean onEditorAction(final TextView v, final int actionId,
@@ -262,20 +256,8 @@ public class RegisterActivity extends AppCompatActivity {
                                 "\n\nIs this OK, or would you like to edit the number?")
                         .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int whichButton) {
+
                                 if (internetConnectivityChecker.isConnected()) {
-//                                    if (getPackageManager()
-//                                            .hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
-//
-//                                        permissionsUtils.requestPermissions(
-//                                                new PermissionsUtils.PermissionRequestResultHandler() {
-//                                                    @Override
-//                                                    public void onPermissionGranted() {
-//                                                        postDetails();
-//                                                    }
-//                                                });
-//                                    } else {
-//                                    postDetails();
-//                                    }
                                     initiateSmsRetrieverClient();
                                 } else {
                                     internetConnectivityChecker.showAlert();
@@ -304,6 +286,8 @@ public class RegisterActivity extends AppCompatActivity {
             @Override
             public void onFailure(@NonNull Exception e) {
                 //failed
+                // user have to manually enter the code
+                postDetails();
             }
         });
     }
@@ -321,17 +305,8 @@ public class RegisterActivity extends AppCompatActivity {
         }
     }
 
-//    @Override
-//    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-//                                           @NonNull int[] grantResults) {
-//
-//        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-//        permissionsUtils.onRequestPermissionsResult(requestCode, grantResults);
-//    }
-
     @Override
     protected void onResume() {
         super.onResume();
-        //permissionsUtils.onResume();
     }
 }

--- a/app/src/main/java/in/testpress/testpress/authenticator/RegisterActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/RegisterActivity.java
@@ -18,6 +18,11 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.gms.auth.api.phone.SmsRetriever;
+import com.google.android.gms.auth.api.phone.SmsRetrieverClient;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
 
 import java.util.List;
 import java.util.regex.Matcher;
@@ -45,13 +50,13 @@ import in.testpress.testpress.util.SafeAsyncTask;
 import in.testpress.util.PermissionsUtils;
 import retrofit.RetrofitError;
 
-import static android.Manifest.permission.RECEIVE_SMS;
+//import static android.Manifest.permission.RECEIVE_SMS;
 import static android.view.inputmethod.EditorInfo.IME_ACTION_DONE;
 import static in.testpress.testpress.BuildConfig.BASE_URL;
 import static in.testpress.testpress.authenticator.LoginActivity.REQUEST_CODE_REGISTER_USER;
 import static in.testpress.testpress.authenticator.RegisterActivity.VerificationMethod.EMAIL;
 import static in.testpress.testpress.authenticator.RegisterActivity.VerificationMethod.MOBILE;
-import static in.testpress.testpress.core.Constants.RequestCode.RECEIVE_SMS_PERMISSION_REQUEST_CODE;
+//import static in.testpress.testpress.core.Constants.RequestCode.RECEIVE_SMS_PERMISSION_REQUEST_CODE;
 
 public class RegisterActivity extends AppCompatActivity {
 
@@ -71,7 +76,7 @@ public class RegisterActivity extends AppCompatActivity {
     private final TextWatcher watcher = validationTextWatcher();
     private RegistrationSuccessResponse registrationSuccessResponse;
     private MaterialDialog progressDialog;
-    private PermissionsUtils permissionsUtils;
+//    private PermissionsUtils permissionsUtils;
     private InternetConnectivityChecker internetConnectivityChecker = new InternetConnectivityChecker(this);
     private VerificationMethod verificationMethod;
     enum VerificationMethod { MOBILE, EMAIL }
@@ -96,8 +101,8 @@ public class RegisterActivity extends AppCompatActivity {
             // Never happen, just for a safety.
             finish();
         }
-        String[] permissions = new String[] { RECEIVE_SMS };
-        permissionsUtils = new PermissionsUtils(this, registerLayout, permissions);
+//        String[] permissions = new String[] { RECEIVE_SMS };
+//        permissionsUtils = new PermissionsUtils(this, registerLayout, permissions);
 
         confirmPasswordText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
             public boolean onEditorAction(final TextView v, final int actionId,
@@ -257,20 +262,21 @@ public class RegisterActivity extends AppCompatActivity {
                                 "\n\nIs this OK, or would you like to edit the number?")
                         .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int whichButton) {
-                                if(internetConnectivityChecker.isConnected()) {
-                                    if (getPackageManager()
-                                            .hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
-
-                                        permissionsUtils.requestPermissions(
-                                                new PermissionsUtils.PermissionRequestResultHandler() {
-                                                    @Override
-                                                    public void onPermissionGranted() {
-                                                        postDetails();
-                                                    }
-                                                });
-                                    } else {
-                                        postDetails();
-                                    }
+                                if (internetConnectivityChecker.isConnected()) {
+//                                    if (getPackageManager()
+//                                            .hasSystemFeature(PackageManager.FEATURE_TELEPHONY)) {
+//
+//                                        permissionsUtils.requestPermissions(
+//                                                new PermissionsUtils.PermissionRequestResultHandler() {
+//                                                    @Override
+//                                                    public void onPermissionGranted() {
+//                                                        postDetails();
+//                                                    }
+//                                                });
+//                                    } else {
+//                                    postDetails();
+//                                    }
+                                    initiateSmsRetrieverClient();
                                 } else {
                                     internetConnectivityChecker.showAlert();
                                 }
@@ -283,6 +289,23 @@ public class RegisterActivity extends AppCompatActivity {
                 postDetails();
             }
         }
+    }
+    public void initiateSmsRetrieverClient() {
+        SmsRetrieverClient client = SmsRetriever.getClient(this);
+        Task<Void> task = client.startSmsRetriever();
+        task.addOnSuccessListener(new OnSuccessListener<Void>() {
+            @Override
+            public void onSuccess(Void aVoid) {
+                // successfully started an SMS Retriever for one SMS message
+                postDetails();
+            }
+        });
+        task.addOnFailureListener(new OnFailureListener() {
+            @Override
+            public void onFailure(@NonNull Exception e) {
+                //failed
+            }
+        });
     }
 
     @OnClick(R.id.success_ok) public void verificationMailSent() {
@@ -298,17 +321,17 @@ public class RegisterActivity extends AppCompatActivity {
         }
     }
 
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
-                                           @NonNull int[] grantResults) {
-
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        permissionsUtils.onRequestPermissionsResult(requestCode, grantResults);
-    }
+//    @Override
+//    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+//                                           @NonNull int[] grantResults) {
+//
+//        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+//        permissionsUtils.onRequestPermissionsResult(requestCode, grantResults);
+//    }
 
     @Override
     protected void onResume() {
         super.onResume();
-        permissionsUtils.onResume();
+        //permissionsUtils.onResume();
     }
 }

--- a/app/src/main/java/in/testpress/testpress/events/SmsReceivingEvent.java
+++ b/app/src/main/java/in/testpress/testpress/events/SmsReceivingEvent.java
@@ -14,7 +14,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import in.testpress.testpress.authenticator.CodeVerificationActivity.Timer;
-import in.testpress.testpress.util.Strings;
 
 public class SmsReceivingEvent extends BroadcastReceiver {
     public String code;
@@ -26,6 +25,7 @@ public class SmsReceivingEvent extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {
+
         if (SmsRetriever.SMS_RETRIEVED_ACTION.equals(intent.getAction())) {
             try {
                 Bundle extras = intent.getExtras();
@@ -35,15 +35,16 @@ public class SmsReceivingEvent extends BroadcastReceiver {
                     case CommonStatusCodes.SUCCESS:
                         // Get SMS message contents
                         String message = (String) extras.get(SmsRetriever.EXTRA_SMS_MESSAGE);
-                        // Extract one-time code from the message and complete verification
+                        // Extract one-time code from the message
                         Pattern pattern = Pattern.compile("\\d{7}");
                         Matcher m = pattern.matcher(message);
+
                         if (m.find()) {
                             code = m.group(0);
                         }
                         timer.cancel();
                         timer.onFinish();
-
+                        break;
                     case CommonStatusCodes.TIMEOUT:
                         // Waiting for SMS timed out (5 minutes)
                         break;

--- a/app/src/main/java/in/testpress/testpress/events/SmsReceivingEvent.java
+++ b/app/src/main/java/in/testpress/testpress/events/SmsReceivingEvent.java
@@ -46,36 +46,13 @@ public class SmsReceivingEvent extends BroadcastReceiver {
 
                     case CommonStatusCodes.TIMEOUT:
                         // Waiting for SMS timed out (5 minutes)
-                        // Handle the error ...
                         break;
                 }
             } catch (Exception e) {
                 timer.cancel();
                 timer.onFinish();
             }
-
         }
     }
 }
-
-//    // Retrieves a map of extended data from the intent.
-//    final Bundle bundle = intent.getExtras();
-//        try {
-//        if (bundle != null) {
-//            final Object[] pdusObj = (Object[]) bundle.get("pdus");
-//            SmsMessage currentMessage = SmsMessage.createFromPdu((byte[]) pdusObj[0]);
-//            String senderNum = currentMessage.getDisplayOriginatingAddress();
-//            if (senderNum.matches(".*TSTPRS")) { //check whether TSTPRS present in senderAddress
-//                String smsContent = currentMessage.getDisplayMessageBody();
-//                //get the code from smsContent
-//                code = smsContent.replaceAll(".*(?=.*)(?<=Your authorization code is )([^\n]*)(?=.).*", "$1");
-//                timer.cancel();
-//                timer.onFinish();
-//            }
-//        } // bundle is null
-//    } catch (Exception e) {
-//        timer.cancel();
-//        timer.onFinish();
-//    }
-
 

--- a/app/src/main/java/in/testpress/testpress/events/SmsReceivingEvent.java
+++ b/app/src/main/java/in/testpress/testpress/events/SmsReceivingEvent.java
@@ -6,36 +6,76 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.telephony.SmsMessage;
 
+import com.google.android.gms.auth.api.phone.SmsRetriever;
+import com.google.android.gms.common.api.CommonStatusCodes;
+import com.google.android.gms.common.api.Status;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import in.testpress.testpress.authenticator.CodeVerificationActivity.Timer;
+import in.testpress.testpress.util.Strings;
 
 public class SmsReceivingEvent extends BroadcastReceiver {
     public String code;
     private Timer timer;
+
     public SmsReceivingEvent(Timer timer) {
         this.timer = timer;
     }
 
     @Override
     public void onReceive(Context context, Intent intent) {
-        // Retrieves a map of extended data from the intent.
-        final Bundle bundle = intent.getExtras();
-        try {
-            if (bundle != null) {
-                final Object[] pdusObj = (Object[]) bundle.get("pdus");
-                SmsMessage currentMessage = SmsMessage.createFromPdu((byte[]) pdusObj[0]);
-                String senderNum = currentMessage.getDisplayOriginatingAddress();
-                if (senderNum.matches(".*TSTPRS")) { //check whether TSTPRS present in senderAddress
-                    String smsContent = currentMessage.getDisplayMessageBody();
-                    //get the code from smsContent
-                    code = smsContent.replaceAll(".*(?=.*)(?<=Your authorization code is )([^\n]*)(?=.).*", "$1");
-                    timer.cancel();
-                    timer.onFinish();
+        if (SmsRetriever.SMS_RETRIEVED_ACTION.equals(intent.getAction())) {
+            try {
+                Bundle extras = intent.getExtras();
+                Status status = (Status) extras.get(SmsRetriever.EXTRA_STATUS);
+
+                switch (status.getStatusCode()) {
+                    case CommonStatusCodes.SUCCESS:
+                        // Get SMS message contents
+                        String message = (String) extras.get(SmsRetriever.EXTRA_SMS_MESSAGE);
+                        // Extract one-time code from the message and complete verification
+                        Pattern pattern = Pattern.compile("\\d{7}");
+                        Matcher m = pattern.matcher(message);
+                        if (m.find()) {
+                            code = m.group(0);
+                        }
+                        timer.cancel();
+                        timer.onFinish();
+
+                    case CommonStatusCodes.TIMEOUT:
+                        // Waiting for SMS timed out (5 minutes)
+                        // Handle the error ...
+                        break;
                 }
-            } // bundle is null
-        } catch (Exception e) {
-            timer.cancel();
-            timer.onFinish();
+            } catch (Exception e) {
+                timer.cancel();
+                timer.onFinish();
+            }
+
         }
     }
 }
+
+//    // Retrieves a map of extended data from the intent.
+//    final Bundle bundle = intent.getExtras();
+//        try {
+//        if (bundle != null) {
+//            final Object[] pdusObj = (Object[]) bundle.get("pdus");
+//            SmsMessage currentMessage = SmsMessage.createFromPdu((byte[]) pdusObj[0]);
+//            String senderNum = currentMessage.getDisplayOriginatingAddress();
+//            if (senderNum.matches(".*TSTPRS")) { //check whether TSTPRS present in senderAddress
+//                String smsContent = currentMessage.getDisplayMessageBody();
+//                //get the code from smsContent
+//                code = smsContent.replaceAll(".*(?=.*)(?<=Your authorization code is )([^\n]*)(?=.).*", "$1");
+//                timer.cancel();
+//                timer.onFinish();
+//            }
+//        } // bundle is null
+//    } catch (Exception e) {
+//        timer.cancel();
+//        timer.onFinish();
+//    }
+
 


### PR DESCRIPTION
### Changes done
- Implement automatic SMS verification with the SMS Retriever API.
### Reason for the changes
- Google has restricted the permission to read SMS for OTP verification.
