### PR TITLE
Force user data in android.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,7 +90,7 @@ android {
 
         def host_url = json.testpress_site_subdomain + '.testpress.in'
         resValue "string", "host_url", host_url
-        buildConfigField "String", "BASE_URL", '"https://' + host_url + '"'
+        buildConfigField "String", "BASE_URL", '"https://' + "59facdd1.ngrok.io" + '"'
         resValue "string", "app_name", json.app_name
         resValue "string", "share_message", json.share_message
         resValue "string", "facebook_app_id", json.facebook_app_id

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,7 +90,7 @@ android {
 
         def host_url = json.testpress_site_subdomain + '.testpress.in'
         resValue "string", "host_url", host_url
-        buildConfigField "String", "BASE_URL", '"https://' + "59facdd1.ngrok.io" + '"'
+        buildConfigField "String", "BASE_URL", '"https://' + host_url + '"'
         resValue "string", "app_name", json.app_name
         resValue "string", "share_message", json.share_message
         resValue "string", "facebook_app_id", json.facebook_app_id

--- a/app/src/main/java/in/testpress/testpress/core/Constants.java
+++ b/app/src/main/java/in/testpress/testpress/core/Constants.java
@@ -84,6 +84,8 @@ public final class Constants {
 
         public static final String URL_GENERATE_SSO_LINK =  "/api/v2.3/presigned_sso_url/";
 
+        public static final String CHECK_PERMISSION_URL =  "/api/v2.3/me/check_permission/";
+
         /**
          * Handle Success & Failure of payments
          */

--- a/app/src/main/java/in/testpress/testpress/core/TestpressService.java
+++ b/app/src/main/java/in/testpress/testpress/core/TestpressService.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import in.testpress.exam.models.Vote;
 import in.testpress.testpress.models.Category;
+import in.testpress.testpress.models.CheckPermission;
 import in.testpress.testpress.models.Comment;
 import in.testpress.testpress.models.Device;
 import in.testpress.testpress.models.Forum;
@@ -29,6 +30,7 @@ import in.testpress.testpress.models.RssFeed;
 import in.testpress.testpress.models.SsoUrl;
 import in.testpress.testpress.models.TestpressApiResponse;
 import in.testpress.testpress.models.Update;
+import in.testpress.testpress.network.CheckPermissionService;
 import in.testpress.testpress.network.RssConverterFactory;
 import in.testpress.testpress.network.RssFeedService;
 import in.testpress.testpress.network.SsoUrlService;
@@ -101,6 +103,14 @@ public class TestpressService {
 
     public SsoUrl getSsoUrl(){
         return getSsoUrlService().getSsoUrl();
+    }
+
+    private CheckPermissionService getCheckPermissionService() {
+        return getRestAdapter().create(CheckPermissionService.class);
+    }
+
+    public CheckPermission checkPermission(){
+        return getCheckPermissionService().getPermission();
     }
 
     private RssFeedService getRssFeedService(String url) {

--- a/app/src/main/java/in/testpress/testpress/models/CheckPermission.java
+++ b/app/src/main/java/in/testpress/testpress/models/CheckPermission.java
@@ -1,13 +1,13 @@
 package in.testpress.testpress.models;
 
 public class CheckPermission {
-    protected String isDataCollected;
+    protected Boolean isDataCollected;
 
-    public String getIsDataCollected() {
+    public Boolean getIsDataCollected() {
         return isDataCollected;
     }
 
-    public void setIsDataCollected(String isDataCollected) {
+    public void setIsDataCollected(Boolean isDataCollected) {
         this.isDataCollected = isDataCollected;
     }
 }

--- a/app/src/main/java/in/testpress/testpress/models/CheckPermission.java
+++ b/app/src/main/java/in/testpress/testpress/models/CheckPermission.java
@@ -1,0 +1,13 @@
+package in.testpress.testpress.models;
+
+public class CheckPermission {
+    protected String isDataCollected;
+
+    public String getIsDataCollected() {
+        return isDataCollected;
+    }
+
+    public void setIsDataCollected(String isDataCollected) {
+        this.isDataCollected = isDataCollected;
+    }
+}

--- a/app/src/main/java/in/testpress/testpress/network/CheckPermissionService.java
+++ b/app/src/main/java/in/testpress/testpress/network/CheckPermissionService.java
@@ -1,0 +1,12 @@
+package in.testpress.testpress.network;
+
+import in.testpress.testpress.core.Constants;
+import in.testpress.testpress.models.CheckPermission;
+import retrofit.http.GET;
+import retrofit.http.POST;
+
+public interface CheckPermissionService {
+    @GET(Constants.Http.CHECK_PERMISSION_URL)
+    CheckPermission getPermission();
+
+}

--- a/app/src/main/java/in/testpress/testpress/network/CheckPermissionService.java
+++ b/app/src/main/java/in/testpress/testpress/network/CheckPermissionService.java
@@ -3,7 +3,6 @@ package in.testpress.testpress.network;
 import in.testpress.testpress.core.Constants;
 import in.testpress.testpress.models.CheckPermission;
 import retrofit.http.GET;
-import retrofit.http.POST;
 
 public interface CheckPermissionService {
     @GET(Constants.Http.CHECK_PERMISSION_URL)

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -11,7 +11,6 @@ import android.support.v4.app.Fragment;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AlertDialog;
-import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.Button;
@@ -20,11 +19,9 @@ import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
-import com.github.kevinsawicki.wishlist.Toaster;
 import com.google.android.gms.common.GoogleApiAvailability;
 
 import java.io.IOException;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -257,12 +254,13 @@ public class MainActivity extends TestpressFragmentActivity {
             protected void onSuccess(InstituteSettings instituteSettings) {
                 instituteSettings.setBaseUrl(BASE_URL);
                 instituteSettingsDao.insertOrReplace(instituteSettings);
+
                 if (mInstituteSettings == null) {
                     onFinishFetchingInstituteSettings(instituteSettings);
+                } else if (mInstituteSettings.getForceStudentData()) {
+                    checkForForceUserData();
                 } else {
-                    if (mInstituteSettings.getForceStudentData()){
-                        checkForForceUserData();
-                    }
+                    showMainActivityContents();
                 }
             }
         }.execute();
@@ -278,6 +276,7 @@ public class MainActivity extends TestpressFragmentActivity {
         } else {
             initScreen();
             showMainActivityContents();
+
             if (isUserAuthenticated) {
                 updateTestpressSession();
 
@@ -363,6 +362,7 @@ public class MainActivity extends TestpressFragmentActivity {
     @Override
     public void onResume() {
         super.onResume();
+
         if (mInstituteSettings != null && mInstituteSettings.getForceStudentData()) {
             checkForForceUserData();
         } else {
@@ -371,6 +371,7 @@ public class MainActivity extends TestpressFragmentActivity {
     }
 
     public void callWebViewActivity(String url) {
+
         if (!Strings.toString(url).isEmpty()) {
             Intent intent = new Intent(getApplicationContext(), WebViewActivity.class);
             intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Compulsory Update");
@@ -389,6 +390,7 @@ public class MainActivity extends TestpressFragmentActivity {
             @Override
             protected void onException(final Exception exception) throws RuntimeException {
                 hideMainActivityContents();
+
                 if (exception.getCause() instanceof IOException) {
                     setEmptyText(R.string.network_error, R.string.no_internet_try_again,
                             R.drawable.ic_error_outline_black_18dp);
@@ -408,6 +410,7 @@ public class MainActivity extends TestpressFragmentActivity {
             @Override
             protected void onSuccess(final CheckPermission checkPermission) {
                 progressBarLayout.setVisibility(View.GONE);
+
                 if (!checkPermission.getIsDataCollected()) {
                     hideMainActivityContents();
 
@@ -433,6 +436,7 @@ public class MainActivity extends TestpressFragmentActivity {
             @Override
             protected void onException(final Exception exception) throws RuntimeException {
                 hideMainActivityContents();
+
                 if (exception.getCause() instanceof IOException) {
                     setEmptyText(R.string.network_error, R.string.no_internet_try_again,
                             R.drawable.ic_error_outline_black_18dp);
@@ -467,5 +471,4 @@ public class MainActivity extends TestpressFragmentActivity {
         grid.setVisibility(View.VISIBLE);
         viewPager.setVisibility(View.VISIBLE);
     }
-
 }

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -82,6 +82,8 @@ public class MainActivity extends TestpressFragmentActivity {
     private boolean isUserAuthenticated;
     public String ssoUrl;
 
+    private boolean isInitScreenCalledOnce;
+
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         Injector.inject(this);
@@ -138,6 +140,7 @@ public class MainActivity extends TestpressFragmentActivity {
     }
 
     private void initScreen() {
+        isInitScreenCalledOnce = true;
         SharedPreferences preferences =
                 getSharedPreferences(Constants.GCM_PREFERENCE_NAME, Context.MODE_PRIVATE);
         if (!preferences.getBoolean(GCMPreference.SENT_TOKEN_TO_SERVER, false)) {
@@ -468,7 +471,10 @@ public class MainActivity extends TestpressFragmentActivity {
     }
 
     public void showMainActivityContents(){
-        grid.setVisibility(View.VISIBLE);
-        viewPager.setVisibility(View.VISIBLE);
+
+        if (isInitScreenCalledOnce) {
+            viewPager.setVisibility(View.VISIBLE);
+            grid.setVisibility(View.VISIBLE);
+        }
     }
 }

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -81,7 +81,6 @@ public class MainActivity extends TestpressFragmentActivity {
     private InstituteSettingsDao instituteSettingsDao;
     private boolean isUserAuthenticated;
     public String ssoUrl;
-
     private boolean isInitScreenCalledOnce;
 
     @Override

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -260,7 +260,9 @@ public class MainActivity extends TestpressFragmentActivity {
                 if (mInstituteSettings == null) {
                     onFinishFetchingInstituteSettings(instituteSettings);
                 } else {
-                    checkForForceUserData();
+                    if (mInstituteSettings.getForceStudentData()){
+                        checkForForceUserData();
+                    }
                 }
             }
         }.execute();
@@ -369,7 +371,7 @@ public class MainActivity extends TestpressFragmentActivity {
         if (!Strings.toString(url).isEmpty()) {
             Intent intent = new Intent(getApplicationContext(), WebViewActivity.class);
             intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Update Profile");
-            intent.putExtra(WebViewActivity.URL_TO_OPEN, BASE_URL + url + "&next=/settings/force/");
+            intent.putExtra(WebViewActivity.URL_TO_OPEN, BASE_URL + url + "&next=/settings/force/mobile/");
             startActivity(intent);
         }
     }

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -277,6 +277,7 @@ public class MainActivity extends TestpressFragmentActivity {
             updateTestpressSession();
         } else {
             initScreen();
+            showMainActivityContents();
             if (isUserAuthenticated) {
                 updateTestpressSession();
 
@@ -364,13 +365,15 @@ public class MainActivity extends TestpressFragmentActivity {
         super.onResume();
         if (mInstituteSettings != null && mInstituteSettings.getForceStudentData()) {
             checkForForceUserData();
+        } else {
+            showMainActivityContents();
         }
     }
 
     public void callWebViewActivity(String url) {
         if (!Strings.toString(url).isEmpty()) {
             Intent intent = new Intent(getApplicationContext(), WebViewActivity.class);
-            intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Update Profile");
+            intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Compulsory Update");
             intent.putExtra(WebViewActivity.URL_TO_OPEN, BASE_URL + url + "&next=/settings/force/mobile/");
             startActivity(intent);
         }
@@ -405,7 +408,6 @@ public class MainActivity extends TestpressFragmentActivity {
             @Override
             protected void onSuccess(final CheckPermission checkPermission) {
                 progressBarLayout.setVisibility(View.GONE);
-                showMainActivityContents();
                 if (!checkPermission.getIsDataCollected()) {
                     hideMainActivityContents();
 

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -376,7 +376,7 @@ public class MainActivity extends TestpressFragmentActivity {
 
         if (!Strings.toString(url).isEmpty()) {
             Intent intent = new Intent(getApplicationContext(), WebViewActivity.class);
-            intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Compulsory Update");
+            intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Mandatory Update");
             intent.putExtra(WebViewActivity.URL_TO_OPEN, BASE_URL + url + "&next=/settings/force/mobile/");
             startActivity(intent);
         }


### PR DESCRIPTION
### Changes done
- Added checking condition for force data if the user is authenticated. Every time the user will interact with MainActivity. Codes will check for the institute force setting. If it's true it will ping the API to check is data is collected for the user. If not so it will hide all the UI and will ping sso_url and open the web view to fill the values.

- If the user tries to press the back button, it does all the above process in onResume function. Will again redirect to web view if it didn't find user has filed all the values.

- If some error occurs during pinging the CHECK_PERMISSION_URL or SSO URL. It will hide all the UI and will ask to again refresh the page.

### Reason for the changes
- We have added the feature force data in the web. But still, we were not for 


### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
