### PR TITLE
Exclude about us menu from authentication checking in the dashboard.

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainMenuFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainMenuFragment.java
@@ -102,10 +102,13 @@ public class MainMenuFragment extends Fragment {
         final boolean isUserAuthenticated = account.length > 0;
         // ToDo get from institute settings
         boolean drupalRssFeedEnabled = false;
+
+        if (!Strings.toString(instituteSettings.getAboutUs()).isEmpty()) {
+            mMenuItemResIds.put(R.string.about_us, R.drawable.about_us);
+        }
+
         if (isUserAuthenticated) {
-            if (!Strings.toString(instituteSettings.getAboutUs()).isEmpty()) {
-                mMenuItemResIds.put(R.string.about_us, R.drawable.about_us);
-            }
+
             if (!instituteSettings.getShowGameFrontend()) {
                 mMenuItemResIds.put(R.string.my_exams, R.drawable.exams);
             }


### PR DESCRIPTION
### Changes done
- Excluded about us menu from authentication checking in the dashboard. Not it will be shown without authentication.

### Reason for the changes
- About us do not require authentication to get values. It not user dependent.

### Stats
- Number of Test Cases - 0

### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
