### PR TITLE
Display client error message while logging

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -345,7 +345,11 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
                         if (e.isNetworkError()) {
                             showAlert(getString(R.string.no_internet_try_again));
                         } else if (e.isClientError()) {
-                            showAlert(getString(R.string.invalid_username_or_password));
+                            if (!e.getMessage().isEmpty()) {
+                                showAlert(e.getMessage());
+                            } else {
+                                showAlert(getString(R.string.invalid_username_or_password));
+                            }
                         } else {
                             showAlert(getString(R.string.testpress_some_thing_went_wrong_try_again));
                         }


### PR DESCRIPTION
### Changes done
- Display client error messages occur while logging, in a pop-up window.

### Reason for the changes
- Earlier we use to show the only invalid `username and password` message for any client error.

### Stats
- Number of Test Cases - N/A

### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
