### PR TITLE
Fix failing travis after increasing the target android version to 28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ android:
 
     # The SDK Version
     - android-22
-    - android-27
+    - android-28
 
     # Additional components
     - extra-google-m2repository


### PR DESCRIPTION
### Changes done
- Increase Android SDK version to 28 for Travis.

### Reason for the changes
-  Travis was failing after increasing the target SDK to 28

### Stats
- Number of Test Cases - N/A