### PR TITLE
Logout user on HTTP code 401

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ import groovy.json.JsonSlurper
 apply plugin: 'com.android.application'
 
 ext {
-    testpressSDK = '1.3.35'
+    testpressSDK = '1.3.36'
 }
 
 dependencies {
@@ -38,6 +38,7 @@ dependencies {
 
     // Gcm
     implementation 'com.google.firebase:firebase-messaging:17.3.4'
+    implementation 'org.greenrobot:eventbus:3.1.1'
 
     // Google Sign In
     implementation 'com.google.android.gms:play-services-auth:16.0.1'

--- a/app/src/main/java/in/testpress/testpress/core/RestErrorHandler.java
+++ b/app/src/main/java/in/testpress/testpress/core/RestErrorHandler.java
@@ -15,6 +15,7 @@ import in.testpress.testpress.events.UnAuthorizedErrorEvent;
 import com.squareup.otto.Bus;
 
 
+import in.testpress.testpress.events.UnAuthorizedUserErrorEvent;
 import in.testpress.testpress.models.TestpressApiErrorResponse;
 import in.testpress.testpress.models.TestpressApiResponse;
 import retrofit.ErrorHandler;
@@ -23,6 +24,7 @@ import retrofit.RetrofitError;
 public class RestErrorHandler implements ErrorHandler {
 
     public static final int HTTP_NOT_FOUND = 404;
+    public static final String HTTP_UNAUTHORIZED = "401 UNAUTHORIZED";
     public static final int INVALID_LOGIN_PARAMETERS = 101;
 
     private Bus bus;
@@ -44,7 +46,10 @@ public class RestErrorHandler implements ErrorHandler {
                 bus.post(new NetworkErrorEvent(cause));
             } else if(isUnAuthorized(cause)) {
                 bus.post(new UnAuthorizedErrorEvent(cause));
-            } else {
+            } else if(isUnAuthorizedUser(cause)) {
+                bus.post(new UnAuthorizedUserErrorEvent());
+            }
+            else {
                 bus.post(new RestAdapterErrorEvent(cause));
             }
         }
@@ -89,5 +94,9 @@ public class RestErrorHandler implements ErrorHandler {
         }
 
         return authFailed;
+    }
+
+    private boolean isUnAuthorizedUser(RetrofitError cause) {
+        return cause.getResponse().getStatus() == 401;
     }
 }

--- a/app/src/main/java/in/testpress/testpress/events/UnAuthorizedUserErrorEvent.java
+++ b/app/src/main/java/in/testpress/testpress/events/UnAuthorizedUserErrorEvent.java
@@ -1,0 +1,4 @@
+package in.testpress.testpress.events;
+
+public class UnAuthorizedUserErrorEvent {
+}


### PR DESCRIPTION
### Changes done
- Logout user on HTTP code 401
- Since logout service is being called in TestpressFragmentActivity which may not be current activity(in some cases) NullPointerException is also handled.

### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
