### PR TITLE
Open only one instance of UserDevicesActivity

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/TestpressFragmentActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/TestpressFragmentActivity.java
@@ -145,6 +145,10 @@ public class TestpressFragmentActivity extends AppCompatActivity {
     protected void onReceiveCustomErrorEvent(final CustomErrorEvent customErrorEvent) {
         if (customErrorEvent.getErrorCode().equals(getString(R.string.PARALLEL_LOGIN_RESTRICTION_ERROR_CODE))) {
             Intent intent = new Intent(this, UserDevicesActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP |
+                    Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+
             try {
                 startActivity(intent);
             } catch (Exception ignore) {}


### PR DESCRIPTION
### Changes done
- Added intent flags to open only one instance of UserDevicesActivity, even if startActivity is called multiple times.

### Reason for the changes
- If the parallel restriction is turned on, then this activity will get called multiple times for multiple requests which will spam the back stack.

### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
