### PR TITLE
Send package_name in check update API

### DIFF
--- a/app/src/main/java/in/testpress/testpress/core/TestpressService.java
+++ b/app/src/main/java/in/testpress/testpress/core/TestpressService.java
@@ -130,9 +130,10 @@ public class TestpressService {
         return getResetPasswordService().resetPassword(emailcode);
     }
 
-    public Update checkUpdate(String version) {
+    public Update checkUpdate(String version, String package_name) {
         HashMap<String, String> versioncode = new HashMap<String, String>();
         versioncode.put("version_code", version);
+        versioncode.put("package_name", package_name);
         return getAuthenticationService().checkUpdate(versioncode);
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -398,7 +398,7 @@ public class MainActivity extends TestpressFragmentActivity {
         new SafeAsyncTask<Update>() {
             @Override
             public Update call() {
-                return testpressService.checkUpdate("" + BuildConfig.VERSION_CODE);
+                return testpressService.checkUpdate("" + BuildConfig.VERSION_CODE, getApplicationContext().getPackageName());
             }
 
             @Override


### PR DESCRIPTION
### Changes done
- Send package_name in check update API
- With this backend can know the package_name from which requests are coming.
- This is useful in case of migration of app from one package name to another

### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
