### PR TITLE
Add easter egg to enable screenshot

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -16,15 +16,19 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
 
+import android.os.Handler;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.Button;
 import android.widget.GridView;
+import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.fragment.app.Fragment;
 
@@ -40,6 +44,7 @@ import javax.inject.Inject;
 import butterknife.ButterKnife;
 import butterknife.InjectView;
 import in.testpress.core.TestpressSdk;
+import in.testpress.core.TestpressSession;
 import in.testpress.course.TestpressCourse;
 import in.testpress.exam.ui.view.NonSwipeableViewPager;
 import in.testpress.testpress.BuildConfig;
@@ -70,6 +75,9 @@ import io.sentry.android.AndroidSentryClientFactory;
 import static in.testpress.testpress.BuildConfig.ALLOW_ANONYMOUS_USER;
 import static in.testpress.testpress.BuildConfig.APPLICATION_ID;
 import static in.testpress.testpress.BuildConfig.BASE_URL;
+import static in.testpress.testpress.ui.utils.EasterEggUtils.enableOrDisableEasterEgg;
+import static in.testpress.testpress.ui.utils.EasterEggUtils.enableScreenShot;
+import static in.testpress.testpress.ui.utils.EasterEggUtils.isEasterEggEnabled;
 
 public class MainActivity extends TestpressFragmentActivity {
 
@@ -130,6 +138,7 @@ public class MainActivity extends TestpressFragmentActivity {
         } else {
             checkUpdate();
         }
+        setupEasterEgg();
     }
 
     @Override
@@ -139,6 +148,43 @@ public class MainActivity extends TestpressFragmentActivity {
         } else {
             super.onBackPressed();
         }
+    }
+
+    private void setupEasterEgg() {
+        Menu navigationMenu = navigationView.getMenu();
+        final MenuItem rateUsButton = navigationMenu.findItem(R.id.rate_us);
+        Button button = new Button(this);
+        button.setAlpha(0);
+        rateUsButton.setActionView(button);
+        rateUsButton.getActionView().setVisibility(View.GONE);
+
+
+        findViewById(R.id.version_info).setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View view) {
+                Toast.makeText(getApplicationContext(), "App version is " + getString(R.string.version), Toast.LENGTH_SHORT).show();
+                enableOrDisableEasterEgg(getApplicationContext(), true);
+                rateUsButton.getActionView().setVisibility(View.VISIBLE);
+                new Handler().postDelayed(new Runnable() {
+                    @Override
+                    public void run() {
+                        rateUsButton.getActionView().setVisibility(View.GONE);
+                        enableOrDisableEasterEgg(getApplicationContext(), false);
+                    }
+                }, 7000);
+                return false;
+            }
+        });
+
+        rateUsButton.getActionView().setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View view) {
+                if (isEasterEggEnabled(getApplicationContext())) {
+                    enableScreenShot(getApplicationContext());
+                }
+                return false;
+            }
+        });
     }
 
     private void setUpNavigationDrawer() {

--- a/app/src/main/java/in/testpress/testpress/ui/utils/EasterEggUtils.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/EasterEggUtils.java
@@ -1,0 +1,38 @@
+package in.testpress.testpress.ui.utils;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.widget.Toast;
+
+import in.testpress.core.TestpressSdk;
+import in.testpress.core.TestpressSession;
+import in.testpress.models.InstituteSettings;
+import in.testpress.testpress.core.Constants;
+
+public class EasterEggUtils {
+    public static final String EASTER_EGG = "easterEgg";
+    public static final String IS_EASTER_EGG_ENABLED = "isEasterEggEnabled";
+
+    private static SharedPreferences getEasterEggPreferences(Context context) {
+        return context.getSharedPreferences(EASTER_EGG, Context.MODE_PRIVATE);
+    }
+
+    public static boolean isEasterEggEnabled(Context context) {
+        return getEasterEggPreferences(context).getBoolean(IS_EASTER_EGG_ENABLED, false);
+    }
+
+    static public void enableOrDisableEasterEgg(Context context, boolean status) {
+        SharedPreferences.Editor editor = getEasterEggPreferences(context).edit();
+        editor.putBoolean(IS_EASTER_EGG_ENABLED, status);
+        editor.apply();
+    }
+
+    public static void enableScreenShot(Context context) {
+        InstituteSettings instituteSettings = TestpressSdk.getTestpressSession(context).getInstituteSettings();
+        instituteSettings.setScreenshotDisabled(false);
+        TestpressSession session = TestpressSdk.getTestpressSession(context);
+        session.setInstituteSettings(instituteSettings);
+        TestpressSdk.setTestpressSession(context,  session);
+        Toast.makeText(context, "Screenshot is enabled ", Toast.LENGTH_SHORT).show();
+    }
+}

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -99,7 +99,7 @@
             android:padding="16dp">
 
             <TextView
-                android:id="@+id/logout"
+                android:id="@+id/version_info"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"


### PR DESCRIPTION
### Changes done
- Added easter egg to enable screenshot
- When the app is closed and reopened again screenshot status will be default again

### To enable easter egg
- Long press on the version number in the navigation drawer (press until you see toast message)
- Next login press on the right end of rate us button in the navigation drawer (press until you see toast message)


### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
