### PR TITLE
Fix Dashboard not displayed in offline

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/fragments/DashboardFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/DashboardFragment.java
@@ -162,6 +162,7 @@ public class DashboardFragment extends Fragment implements
             this.exception = exception;
             showError(getErrorMessage(exception));
             getLoaderManager().destroyLoader(loader.getId());
+            adapter.setResponse(getDashboardDataPreferences(getContext()));
             return;
         }
         Gson gson = new GsonBuilder().setPrettyPrinting().create();


### PR DESCRIPTION
### Changes done
- If network error(when the app is offline) occurs, dashboard data stored in shared preferences is used.

### Stats
- Number of Test Cases - NA

### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
