### PR TITLE
Fix deeplink not working bug

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/SplashScreenActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/SplashScreenActivity.java
@@ -65,7 +65,7 @@ public class SplashScreenActivity extends Activity {
 
             @Override
             public void run() {
-                deeplinkHandler.handleDeepLinkUrl(getIntent().getData());
+                deeplinkHandler.handleDeepLinkUrl(getIntent().getData(), true);
             }
         }, SPLASH_TIME_OUT);
     }

--- a/app/src/main/java/in/testpress/testpress/ui/adapters/OffersCarouselAdapter.java
+++ b/app/src/main/java/in/testpress/testpress/ui/adapters/OffersCarouselAdapter.java
@@ -66,7 +66,7 @@ public class OffersCarouselAdapter extends RecyclerView.Adapter<OffersCarouselAd
                 Activity activity = (Activity) context;
                 DeeplinkHandler deeplinkHandler = new DeeplinkHandler(activity, serviceProvider);
                 Uri uri = Uri.parse(banners.get(position).getUrl());
-                deeplinkHandler.handleDeepLinkUrl(uri);
+                deeplinkHandler.handleDeepLinkUrl(uri, false);
 //                Intent intent = new Intent(context, WebViewActivity.class);
 //                intent.putExtra(WebViewActivity.URL_TO_OPEN, banners.get(position).getUrl());
 //                context.startActivity(intent);

--- a/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
@@ -3,7 +3,6 @@ package in.testpress.testpress.ui.utils;
 import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
-import android.util.Log;
 
 import java.util.List;
 
@@ -111,15 +110,15 @@ public class DeeplinkHandler {
                     authenticateUserAndOpen(uri);
                     break;
                 default:
-                    openBrowerOrGotoHome(uri, fromSplashScreen);
+                    openBrowserOrGotoHome(uri, fromSplashScreen);
                     break;
             }
         } else {
-            openBrowerOrGotoHome(uri, fromSplashScreen);
+            openBrowserOrGotoHome(uri, fromSplashScreen);
         }
     }
 
-    private void openBrowerOrGotoHome(Uri uri, boolean fromSplashScreen) {
+    private void openBrowserOrGotoHome(Uri uri, boolean fromSplashScreen) {
         if (fromSplashScreen) {
             gotoHome();
         } else {

--- a/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
@@ -40,7 +40,7 @@ public class DeeplinkHandler {
         this.serviceProvider = serviceProvider;
     }
 
-    public void handleDeepLinkUrl(Uri uri) {
+    public void handleDeepLinkUrl(Uri uri, boolean fromSplashScreen) {
         if (uri != null && uri.getPathSegments().size() > 0) {
             List<String> pathSegments = uri.getPathSegments();
             switch (pathSegments.get(0)) {
@@ -111,12 +111,19 @@ public class DeeplinkHandler {
                     authenticateUserAndOpen(uri);
                     break;
                 default:
-                    CommonUtils.openUrlInBrowser(activity, uri);
-                    activity.finish();
+                    openBrowerOrGotoHome(uri, fromSplashScreen);
                     break;
             }
         } else {
+            openBrowerOrGotoHome(uri, fromSplashScreen);
+        }
+    }
+
+    private void openBrowerOrGotoHome(Uri uri, boolean fromSplashScreen) {
+        if (fromSplashScreen) {
             gotoHome();
+        } else {
+            CommonUtils.openUrlInBrowser(activity, uri);
         }
     }
 


### PR DESCRIPTION
- We have a class DeepLinkHandler which will handle deep links
- Problem is we are using the deep link handler for 2 cases.
1. When a user clicks link outside from app
2. When user click some link inside the app
- Right now for both cases it is doing same thing (simply opens the app)
- For 1, if link is not recognized then it should open the app and show the main screen
- For 2, if link is not recognized then it should open link in the browser


### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
