### PR TITLE
Fix incorrect registration behaviour

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="logout_confirm_message">Are you sure you want to log out?</string>
 
     <string name="activation_email_sent_message">An activation email has been sent. Please check your email and click on the link to activate your account.</string>
+    <string name="register_success_message">Registered Successfully.Please login to continue</string>
     <string name="activate">Activate</string>
     <string name="activate_completed_title">Activation complete</string>
     <string name="activate_completed_message">Thanks, activation complete! You may now login using the username and password you set at registration.</string>


### PR DESCRIPTION
### Changes done
- Fixed showing verify email when there is no verification method present

### Reason for the changes
- The institute has verification method as no verification. But the app seems to be misleading with a message telling that verification email is sent.
