### PR TITLE
Remove Redundant try catch

### DIFF
--- a/app/src/main/java/in/testpress/testpress/repository/RegisterRepository.kt
+++ b/app/src/main/java/in/testpress/testpress/repository/RegisterRepository.kt
@@ -19,18 +19,12 @@ open class RegisterRepository(val testpressService: TestpressService) {
 
         object : SafeAsyncTask<Boolean>() {
             override fun call(): Boolean {
-                try {
-                    registrationSuccessResponse = testpressService.register(userDetails["username"],
-                            userDetails["email"],
-                            userDetails["password"],
-                            userDetails["phone"],
-                            userDetails["country_code"]
-                    )
-                } catch (e: Exception) {
-                    CoroutineScope(Dispatchers.Main).launch {
-                        result.postValue(Resource.error(e, null))
-                    }
-                }
+                registrationSuccessResponse = testpressService.register(userDetails["username"],
+                        userDetails["email"],
+                        userDetails["password"],
+                        userDetails["phone"],
+                        userDetails["country_code"]
+                )
                 return true
             }
 

--- a/app/src/main/java/in/testpress/testpress/repository/RegisterRepository.kt
+++ b/app/src/main/java/in/testpress/testpress/repository/RegisterRepository.kt
@@ -5,8 +5,11 @@ import `in`.testpress.testpress.core.TestpressService
 import `in`.testpress.testpress.models.RegistrationSuccessResponse
 import `in`.testpress.testpress.util.SafeAsyncTask
 import androidx.lifecycle.MutableLiveData
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
-open class RegisterRepository(val testPressService: TestpressService) {
+open class RegisterRepository(val testpressService: TestpressService) {
 
     var result = MutableLiveData<Resource<RegistrationSuccessResponse>>()
 
@@ -16,12 +19,18 @@ open class RegisterRepository(val testPressService: TestpressService) {
 
         object : SafeAsyncTask<Boolean>() {
             override fun call(): Boolean {
-                registrationSuccessResponse = testPressService.register(userDetails["username"],
-                        userDetails["email"],
-                        userDetails["password"],
-                        userDetails["phone"],
-                        userDetails["country_code"]
-                )
+                try {
+                    registrationSuccessResponse = testpressService.register(userDetails["username"],
+                            userDetails["email"],
+                            userDetails["password"],
+                            userDetails["phone"],
+                            userDetails["country_code"]
+                    )
+                } catch (e: Exception) {
+                    CoroutineScope(Dispatchers.Main).launch {
+                        result.postValue(Resource.error(e, null))
+                    }
+                }
                 return true
             }
 
@@ -32,7 +41,7 @@ open class RegisterRepository(val testPressService: TestpressService) {
 
             override fun onSuccess(authSuccess: Boolean?) {
                 super.onSuccess(authSuccess)
-                result.value = Resource.success(registrationSuccessResponse)
+                result.postValue(Resource.success(registrationSuccessResponse))
             }
         }.execute()
     }


### PR DESCRIPTION
Since the exception is handled in the onException function, the catch block is unnecessary.