### PR TITLE
Fix: Downloaded videos should not get deleted when logged out

### DIFF
--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -123,7 +123,6 @@ public class TestpressServiceProvider {
         progressDialog.setCancelable(false);
         UIUtils.setIndeterminateDrawable(activity, progressDialog, 4);
         progressDialog.show();
-        deleteDownloadedVideos(activity);
         serviceProvider.invalidateAuthToken(activity);
         SharedPreferences preferences = activity.getSharedPreferences(Constants.GCM_PREFERENCE_NAME,
                 Context.MODE_PRIVATE);
@@ -131,7 +130,6 @@ public class TestpressServiceProvider {
         preferences.edit().putBoolean(GCMPreference.SENT_TOKEN_TO_SERVER, false).apply();
         CommonUtils.registerDevice(activity, testpressService, serviceProvider);
         TestpressApplication.clearDatabase(activity);
-        TestpressSDKDatabase.clearDatabase(activity);
         logoutService.logout(new Runnable() {
             @Override
             public void run() {
@@ -147,11 +145,5 @@ public class TestpressServiceProvider {
                 activity.startActivity(intent);
             }
         });
-    }
-
-    private void deleteDownloadedVideos(Activity activity) {
-        Executor executor = Executors.newSingleThreadExecutor();
-        executor.execute(() -> TestpressDatabase.Companion.invoke(activity).clearAllTables());
-        DownloadService.sendRemoveAllDownloads(activity, VideoDownloadService.class, false);
     }
 }


### PR DESCRIPTION
### Changes done
- Removed the method call which will delete the db data while logout