### PR TITLE
Rename Dashboard Preference

### DIFF
--- a/app/src/main/java/in/testpress/testpress/util/PreferenceManager.java
+++ b/app/src/main/java/in/testpress/testpress/util/PreferenceManager.java
@@ -18,7 +18,7 @@ public class PreferenceManager {
 
     private static final String PREF_KEY_LAUNCHED_TIMES = "launchedTimes";
 
-    public static final String DASHBOARD_DATA = "dashboardData";
+    public static final String DASHBOARD_DATA = "dashboardDataPreference";
 
     private PreferenceManager() {
     }


### PR DESCRIPTION
To clear the data already stored in the Dashboard shared Pref needs to be deleted. Hence the Shared Pref name is renamed