### PR TITLE
Fix app link is not present in share option

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -7,6 +7,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.text.TextUtils;
 
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
@@ -159,7 +160,7 @@ public class HandleMainMenu {
         Intent share = new Intent(Intent.ACTION_SEND);
         share.setType("text/plain");
         String appLink = "https://play.google.com/store/apps/details?id=" + activity.getPackageName();
-        if (instituteSettings.getAppShareLink() != null) {
+        if (!TextUtils.isEmpty(instituteSettings.getAppShareLink())) {
             appLink = instituteSettings.getAppShareLink();
         }
         share.putExtra(Intent.EXTRA_TEXT, activity.getString(R.string.share_message) +


### PR DESCRIPTION
### Fixes
- App link was not present in the share option. Previously, there was a check if the appLink from Institute settings is null. Now added another check if the string was empty. If both condition satisfies, the link from settings will be shared, or the link with default package name will be shared.

### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
