### PR TITLE
Fix image get cropped in dashboard

### DIFF
--- a/app/src/main/res/layout/content_carousel_item.xml
+++ b/app/src/main/res/layout/content_carousel_item.xml
@@ -22,7 +22,7 @@
             android:id="@+id/image_view"
             android:layout_width="155dp"
             android:layout_height="87dp"
-            android:scaleType="centerCrop"
+            android:scaleType="centerInside"
             android:background="@drawable/border_rectangle_light" />
 
         <ImageView

--- a/app/src/main/res/layout/content_carousel_item.xml
+++ b/app/src/main/res/layout/content_carousel_item.xml
@@ -22,7 +22,7 @@
             android:id="@+id/image_view"
             android:layout_width="155dp"
             android:layout_height="87dp"
-            android:scaleType="centerInside"
+            android:scaleType="centerCrop"
             android:background="@drawable/border_rectangle_light" />
 
         <ImageView

--- a/app/src/main/res/layout/course_carousel_item.xml
+++ b/app/src/main/res/layout/course_carousel_item.xml
@@ -24,7 +24,7 @@
                 android:layout_height="match_parent"
                 android:cropToPadding="true"
                 android:background="@drawable/border_rectangle_light"
-                android:scaleType="centerCrop" />
+                android:scaleType="centerInside" />
         </androidx.cardview.widget.CardView>
     </FrameLayout>
 


### PR DESCRIPTION
### Changes done
- Change image scale type from `centerCrop` to `centerInside`

### Reason for the changes
- In some cases, the thumbnail is getting cropped and full view is not visible. So made the change to display the complete image.

### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
