### PR TITLE
fix: Fix the bug while fetching app config through API

### DIFF
--- a/fastlane/actions/get_app_config.rb
+++ b/fastlane/actions/get_app_config.rb
@@ -6,7 +6,7 @@ module Fastlane
   module Actions
     class GetAppConfigAction < Action
       def self.run(params)
-        uri = URI("#{params[:subdomain]}.testpress.in/api/v2.5/admin/android/app-config/")
+        uri = URI("https://#{params[:subdomain]}.testpress.in/api/v2.5/admin/android/app-config/")
         request = Net::HTTP::Get.new(uri)
         request["API-access-key"] = ENV["API_ACCESS_KEY"]
         http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
- This issue is we haven't constructed the URL correctly in Fastlane, this causes the `Not an HTTP URI` error while fetching. that is fixed in this commit. 

### Guidelines
- [x] Have you self-reviewed this PR in context to the previous PR feedback?
