### PR TITLE
fix: Fix incorrect image replacement in fastlane automation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,8 +11,8 @@ desc "Replace images"
 lane :replace_images do |params|
   config_json = params[:app_config]
   download_file(url: config_json["splash_screen"], destination_path: './app/src/main/res/drawable/splash_screen.png')
-  download_file(url: config_json["splash_screen_land"], destination_path: './app/src/main/res/drawable-land/splash_screen.png')
-  download_file(url: config_json["splash_screen_large"], destination_path: './app/src/main/res/drawable-large/splash_screen.png')
+  download_file(url: config_json["splash_screen_large"], destination_path: './app/src/main/res/drawable-land/splash_screen.png')
+  download_file(url: config_json["splash_screen_land"], destination_path: './app/src/main/res/drawable-large/splash_screen.png')
   download_file(url: config_json["splash_screen_land_large"], destination_path: './app/src/main/res/drawable-large-land/splash_screen.png')
   download_file(url: config_json["notification_mdpi"], destination_path: './app/src/main/res/drawable-mdpi/ic_stat_notification.png')
   download_file(url: config_json["notification_hdpi"], destination_path: './app/src/main/res/drawable-hdpi/ic_stat_notification.png')


### PR DESCRIPTION
- The issue is we replaced splash screen `1280 * 720` with `2048 * 1536`  and `2048 * 1536` with `1280 * 720`, and this is fixed in this commit.

### Guidelines
- [x] Have you self-reviewed this PR in context to the previous PR feedback?
