### PR TITLE
fix: Fix version number and name not updated in app deployment

### DIFF
--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -7,6 +7,8 @@ module Fastlane
     class ModifyConfigJsonFileAction < Action
       def self.run(params)     
         fields_to_change = [
+          "version",
+          "version_code",
           "allow_anonymous_user",
           "package_name", 
           "app_name", 


### PR DESCRIPTION
- The issue we haven't replaced the version code and version name in the config JSON with the institute version. this is fixed in this commit.

### Guidelines
- [x] Have you self-reviewed this PR in context to the previous PR feedback?
