### PR TITLE
fix: Remove ref input from build_app Github action

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -8,10 +8,6 @@ on:
         required: true
         default: "master"
 
-      tag:
-        description: "Enter the version tag or Commit SHA "
-        required: true
-        default: "1.0.0"
 
 jobs:
   build_app:
@@ -47,8 +43,6 @@ jobs:
 
       - name: Checkout the repository
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.tag }}
 
       - name: Setup ruby and fastlane
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
- Removed ref input from build_app Github action, because by default GitHub action asks for a branch or tag to run on, so it's redundant to have a ref input field in the workflow.

### Guidelines
- [x] Have you self-reviewed this PR in context to the previous PR feedback?
