### PR TITLE
fix: Fix app crash while logout if app dont have facebook app id

### DIFF
--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -6,6 +6,9 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.text.TextUtils;
 
 import com.facebook.FacebookSdk;
 import com.facebook.login.LoginManager;
@@ -53,10 +56,28 @@ public class TestpressServiceProvider {
 
     public void invalidateAuthToken(Context context) {
         authToken = null;
-        FacebookSdk.sdkInitialize(context.getApplicationContext());
-        LoginManager.getInstance().logOut();
+        if (hasFacebookAppID(context)) {
+            FacebookSdk.sdkInitialize(context.getApplicationContext());
+            LoginManager.getInstance().logOut();
+        }
         TestpressSdk.clearActiveSession(context);
     }
+
+    private boolean hasFacebookAppID(Context context){
+        ApplicationInfo applicationInfo = getApplicationInfo(context);
+        if (applicationInfo == null) return false;
+        String appId = applicationInfo.metaData.getString(FacebookSdk.APPLICATION_ID_PROPERTY);
+        return !TextUtils.isEmpty(appId);
+    }
+
+    private ApplicationInfo getApplicationInfo(Context context){
+        try {
+            return context.getPackageManager().getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+        } catch (PackageManager.NameNotFoundException e) {
+            return null;
+        }
+    }
+
     /**
      * Get service for configured key provider
      * <p/>


### PR DESCRIPTION
- We are setting the Facebook app id as an empty string in the config json if the institute doesn't have one while customizing using Fastlane, because of this, the app crashes when the user tries to logout from the app,
- Because FacebookSDK raises an exception if we initialize it with an empty string as Facebook application id, this unhandled Exception causing App crash.
- This is fixed by only initializing the FacebookSDK if the institute has a Facebook app id. 


### Guidelines
- [x] Have you self-reviewed this PR in context to the previous PR feedback?
