### PR TITLE
fix: Update NDK version to 21.4 for gradle build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,6 +124,7 @@ android {
 
     compileSdkVersion 30
     buildToolsVersion '30.0.3'
+    ndkVersion "21.0.6113669"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,7 +124,7 @@ android {
 
     compileSdkVersion 30
     buildToolsVersion '30.0.3'
-    ndkVersion "21.0.6113669"
+    ndkVersion "21.4.7075529"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
### Reason for the changes
- While running the GitHub action for app build, we are getting this issue `No version of NDK matched the requested version 21.0.6113669. Versions available locally: 21.4.7075529, 23.2.8568313, 24.0.8215888` that is fixed in this commit by using NDK version 21.4.

### Guidelines
- [x] Have you self-reviewed this PR in context to the previous PR feedback?
