### PR TITLE
fix: Fix kotlin compile time error which caused by 0a19197

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
@@ -195,29 +195,33 @@ class LoginActivityV2: ActionBarAccountAuthenticatorActivity(), LoginNavigationI
         } else {
             result.signInAccount!!.email
         }
-        TestpressSdk.initialize(this, settings, userId, accessToken, TestpressSdk.Provider.GOOGLE,
-            object : TestpressCallback<TestpressSession?>() {
-                override fun onSuccess(response: TestpressSession?) {
-                    val authToken = response?.token
-                    if (authToken != null) {
-                        onLoginSuccess(username, authToken)
-                    }
-                }
-
-                override fun onException(e: TestpressException) {
-                    if (e.isNetworkError) {
-                        UIUtils.showAlert(this@LoginActivityV2, getString(R.string.no_internet_try_again))
-                    } else if (e.isClientError) {
-                        if (e.message?.isNotEmpty() == true) {
-                            UIUtils.showAlert(this@LoginActivityV2, e.message!!)
-                        } else {
-                            UIUtils.showAlert(this@LoginActivityV2,getString(R.string.invalid_username_or_password))
+        if (userId != null && accessToken != null) {
+            TestpressSdk.initialize(this, settings, userId, accessToken, TestpressSdk.Provider.GOOGLE,
+                object : TestpressCallback<TestpressSession?>() {
+                    override fun onSuccess(response: TestpressSession?) {
+                        val authToken = response?.token
+                        if (authToken != null) {
+                            if (username != null) {
+                                onLoginSuccess(username, authToken)
+                            }
                         }
-                    } else {
-                        UIUtils.showAlert(this@LoginActivityV2,getString(R.string.testpress_some_thing_went_wrong_try_again))
                     }
-                }
-            })
+
+                    override fun onException(e: TestpressException) {
+                        if (e.isNetworkError) {
+                            UIUtils.showAlert(this@LoginActivityV2, getString(R.string.no_internet_try_again))
+                        } else if (e.isClientError) {
+                            if (e.message?.isNotEmpty() == true) {
+                                UIUtils.showAlert(this@LoginActivityV2, e.message!!)
+                            } else {
+                                UIUtils.showAlert(this@LoginActivityV2,getString(R.string.invalid_username_or_password))
+                            }
+                        } else {
+                            UIUtils.showAlert(this@LoginActivityV2,getString(R.string.testpress_some_thing_went_wrong_try_again))
+                        }
+                    }
+                })
+        }
     }
 
     private fun getInstituteSettings(): `in`.testpress.models.InstituteSettings {


### PR DESCRIPTION
- After updating the google auth dependencies, GoogleSignInResult getId and getIdToken methods return optional null, which causes Kotlin compile time error because accessed those values without null check. 
- Which was fixed in the commit by accessing the return value after the null check.


### Guidelines
- [x] Have you self-reviewed this PR in context to the previous PR feedback?
