### PR TITLE
fix: Display app_name watermark from Institute settings in QuizReviewFragnment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 ext {
-    testpressSDK = '1.4.67'
+    testpressSDK = '1.4.69'
 }
 
 def jsonFile = file('src/main/assets/config.json')

--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -133,6 +133,7 @@ public class TestpressServiceProvider {
             }
             settings.setAppShareText(SHARE_MESSAGE + activity.getString(R.string.get_it_at) + appLink);
             settings.setGrowthHackEnabled(GROWTH_HACKS_ENABLED);
+            settings.setAppName(activity.getString(R.string.app_name));
             TestpressSdk.setTestpressSession(activity, new TestpressSession(settings, authToken));
         }
 


### PR DESCRIPTION
### Changes done
- Added new Testpress SDK version 1.4.69
- set app_name in institute settings

### Reason for the changes
- Issue is watermark in Quiz review Fragment is displayed as "Testpress SDK" instead of app name

### Stats
- Number of Test Cases - Nil 

### Guidelines
- [ ] Have you self reviewed this PR in context to the previous PR feedbacks?
