### PR TITLE
fix: Replace bookmark import statement

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainMenuFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainMenuFragment.java
@@ -34,6 +34,7 @@ import butterknife.InjectView;
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.exam.TestpressExam;
+import in.testpress.course.TestpressCourse;
 import in.testpress.store.TestpressStore;
 import in.testpress.testpress.Injector;
 import in.testpress.testpress.R;
@@ -265,7 +266,7 @@ public class MainMenuFragment extends Fragment {
                 TestpressExam.showCategories(getActivity(), true, session);
                 break;
             case R.string.bookmarks:
-                TestpressExam.showBookmarks(getActivity(), session);
+                TestpressCourse.showBookmarks(getActivity(), session);
                 break;
             case R.string.analytics:
                 TestpressExam.showAnalytics(getActivity(), SUBJECT_ANALYTICS_PATH, session);

--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -13,6 +13,7 @@ import android.util.Log;
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.exam.TestpressExam;
+import in.testpress.course.TestpressCourse;
 import in.testpress.store.TestpressStore;
 import in.testpress.testpress.R;
 import in.testpress.testpress.TestpressApplication;
@@ -136,7 +137,7 @@ public class HandleMainMenu {
                 TestpressExam.showCategories(activity, true, session);
                 break;
             case R.string.bookmarks:
-                TestpressExam.showBookmarks(activity, session);
+                TestpressCourse.showBookmarks(activity, session);
                 break;
             case R.string.analytics:
                 TestpressExam.showAnalytics(activity, SUBJECT_ANALYTICS_PATH, session);


### PR DESCRIPTION
### Changes done
-  Replace bookmark import in ManiMenuFragment and HandleMainmenu

### Reason for the changes
- Bookmark functionality moved from exam library to course library


### Stats
- Number of Test Cases - Nil

### Guidelines
- [ ] Have you self reviewed this PR in context to the previous PR feedbacks?
