### PR TITLE
fix: App crash while opening via shared link

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
@@ -143,22 +143,17 @@ public class DeeplinkHandler {
                         switch (pathSegments.get(0)) {
                             case "exams":
                                 if (pathSegments.size() == 2) {
-                                    if (!pathSegments.get(1).equals("available") ||
-                                            !pathSegments.get(1).equals("upcoming") ||
-                                            !pathSegments.get(1).equals("history")) {
-
-                                        TestpressExam.showExamAttemptedState(
-                                                activity,
-                                                pathSegments.get(1),
-                                                testpressSession
-                                        );
-                                        return;
+                                    if (pathSegments.get(1).equals("available") ||
+                                            pathSegments.get(1).equals("upcoming") ||
+                                            pathSegments.get(1).equals("history")) {
+                                        TestpressExam.show(activity, testpressSession);
                                     }
+                                    else {
+                                        gotoHome();
+                                    }
+                                    activity.finish();
                                 }
-                                TestpressExam.show(activity, testpressSession);
-                                activity.finish();
                                 break;
-
                             case "analytics":
                                 TestpressExam.showAnalytics(activity, SUBJECT_ANALYTICS_PATH,
                                         testpressSession);

--- a/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
@@ -147,11 +147,11 @@ public class DeeplinkHandler {
                                             pathSegments.get(1).equals("upcoming") ||
                                             pathSegments.get(1).equals("history")) {
                                         TestpressExam.show(activity, testpressSession);
+                                        activity.finish();
                                     }
                                     else {
                                         gotoHome();
                                     }
-                                    activity.finish();
                                 }
                                 break;
                             case "analytics":


### PR DESCRIPTION
### Changes done
-  Added validation for selected link to open ExamListViewActivity
-  Open MainActivity for other links

### Reason for the changes
-  App crash while opening the app using the link


### Stats
- Number of Test Cases -  Nil

### Guidelines
- [ ] Have you self reviewed this PR in context to the previous PR feedbacks?
