### PR TITLE
fix: Fix mergeReleaseNativeLibs gradle task failure in github action

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -193,6 +193,12 @@ android {
         exclude 'META-INF/proguard/androidx-annotations.pro'
         exclude 'META-INF/proguard/coroutines.pro'
         exclude 'LICENSE.txt'
+
+        // Error: More than one file was found with OS independent path
+        pickFirst 'lib/x86/libc++_shared.so'
+        pickFirst 'lib/x86_64/libc++_shared.so'
+        pickFirst 'lib/armeabi-v7a/libc++_shared.so'
+        pickFirst 'lib/arm64-v8a/libc++_shared.so'
     }
 
     signingConfigs {


### PR DESCRIPTION
- We are getting this error at runtime `More than one file was found with OS independent path 'lib/arm64-v8a/libc++_shared.so'.` in the mergeReleaseNativeLibs Gradle task, this was fixed in this commit by picking the first file while packing.



### Guidelines
- [x] Have you self-reviewed this PR in context to the previous PR feedback?
