### PR TITLE
fix:able to open non institute links in app webview

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -170,8 +170,12 @@ android {
         if (json.display_username_on_video != null) {
             buildConfigField "boolean", "DISPLAY_USERNAME_ON_VIDEO", "" + json.display_username_on_video
         }
-        if (json.white_labeled_host_url != null && json.white_labeled_host_url != "") {
+        if (json.white_labeled_host_url == "" || json.white_labeled_host_url == null) {
+            resValue "string", "white_labeled_host_url", 'no_white_labeled_host_url'
+            buildConfigField "String", "WHITE_LABELED_HOST_URL", '"no_white_labeled_host_url"'
+        } else {
             resValue "string", "white_labeled_host_url", json.white_labeled_host_url
+            buildConfigField "String", "WHITE_LABELED_HOST_URL", '"https://' + json.white_labeled_host_url + '"'
         }
 
         applicationId json.package_name

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -171,8 +171,8 @@ android {
             buildConfigField "boolean", "DISPLAY_USERNAME_ON_VIDEO", "" + json.display_username_on_video
         }
         if (json.white_labeled_host_url == "" || json.white_labeled_host_url == null) {
-            resValue "string", "white_labeled_host_url", 'no_white_labeled_host_url'
-            buildConfigField "String", "WHITE_LABELED_HOST_URL", '"no_white_labeled_host_url"'
+            resValue "string", "white_labeled_host_url", host_url
+            buildConfigField "String", "WHITE_LABELED_HOST_URL", '"https://' + host_url + '"'
         } else {
             resValue "string", "white_labeled_host_url", json.white_labeled_host_url
             buildConfigField "String", "WHITE_LABELED_HOST_URL", '"https://' + json.white_labeled_host_url + '"'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,6 +55,8 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" android:host="@string/host_url"/>
                 <data android:scheme="http" android:host="@string/host_url" />
+                <data android:scheme="https" android:host="@string/white_labeled_host_url"/>
+                <data android:scheme="http" android:host="@string/white_labeled_host_url"/>
             </intent-filter>
         </activity>
         <activity

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -304,7 +304,7 @@ public class WebViewActivity extends BaseToolBarActivity {
             Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
             startActivity(i);
         } catch (Exception e){
-            Toast.makeText(getApplicationContext(),"Not able to open this Link",Toast.LENGTH_SHORT).show();
+            Toast.makeText(getApplicationContext(),"No suitable app was found to open this URL. Please install any browser app",Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -185,7 +185,11 @@ public class WebViewActivity extends BaseToolBarActivity {
 
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                openInstituteUrlOnly(view,url);
+                if (isInstituteURL(url)) {
+                    view.loadUrl(url);
+                } else {
+                    openInExternal(url);
+                }
                 return true;
             }
 
@@ -291,16 +295,16 @@ public class WebViewActivity extends BaseToolBarActivity {
         });
     }
 
-    private void openInstituteUrlOnly(WebView view,String url){
-        if(url.contains(BuildConfig.BASE_URL) || url.contains(BuildConfig.WHITE_LABELED_HOST_URL)) {
-            view.loadUrl(url);
-        } else {
-            try {
-                Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                startActivity(i);
-            } catch (Exception e){
-                Toast.makeText(getApplicationContext(),"Not able to open this Link",Toast.LENGTH_SHORT).show();
-            }
+    private Boolean isInstituteURL(String url){
+        return url.contains(BuildConfig.BASE_URL) || url.contains(BuildConfig.WHITE_LABELED_HOST_URL);
+    }
+
+    private void openInExternal(String url){
+        try {
+            Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            startActivity(i);
+        } catch (Exception e){
+            Toast.makeText(getApplicationContext(),"Not able to open this Link",Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -41,6 +41,7 @@ import java.util.Date;
 
 import javax.inject.Inject;
 
+import in.testpress.testpress.BuildConfig;
 import in.testpress.testpress.Injector;
 import in.testpress.testpress.R;
 import in.testpress.testpress.TestpressServiceProvider;
@@ -184,7 +185,8 @@ public class WebViewActivity extends BaseToolBarActivity {
 
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                return false;
+                openInstituteUrlOnly(view,url);
+                return true;
             }
 
             @Override
@@ -287,6 +289,19 @@ public class WebViewActivity extends BaseToolBarActivity {
                 return true;
             }
         });
+    }
+
+    private void openInstituteUrlOnly(WebView view,String url){
+        if(url.contains(BuildConfig.BASE_URL) || url.contains(BuildConfig.WHITE_LABELED_HOST_URL)) {
+            view.loadUrl(url);
+        } else {
+            try {
+                Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                startActivity(i);
+            } catch (Exception e){
+                Toast.makeText(getApplicationContext(),"Not able to open this Link",Toast.LENGTH_SHORT).show();
+            }
+        }
     }
 
     private void parseIntent() {


### PR DESCRIPTION
### Changes done
-  Added validation to institute URL while using webview
-  Added auto-generation of white labeled URL in Gradle file
-  Added deep link URL in Android Manifest for the custom domain to open the app

### Reason for the changes
-  user is able to open other links in the institute app

### Stats
- Number of Test Cases - NIL

### Guidelines
- [ ] Have you self reviewed this PR in context to the previous PR feedbacks?
