### PR TITLE
fix: Exclude brilliantpala and veranda apps while releasing update for all

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,6 +8,9 @@ lane :release_update_to do |params|
   if params[:subdomain] == "all"
     subdomains = fetch_subdomains
     subdomains.each do |subdomain|
+      if ['verandalearning', 'brilliantpalalms', 'brilliantpalaclasses'].include? subdomain
+        next
+      end
       release_update(subdomain: subdomain)
     end
   else

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,7 +8,7 @@ lane :release_update_to do |params|
   if params[:subdomain] == "all"
     subdomains = fetch_subdomains
     subdomains.each do |subdomain|
-      if ['verandalearning', 'brilliantpalalms', 'brilliantpalaclasses'].include? subdomain
+      if ['verandalearning', 'brilliantpalalms', 'brilliantpalaclasses', "race"].include? subdomain
         next
       end
       release_update(subdomain: subdomain)


### PR DESCRIPTION
- Because these apps must be released from their customized branch, not from the master.  

### Guidelines
- [x] Have you self-reviewed this PR in context to the previous PR feedback?
