### PR TITLE
fix: Allow WebView for user registration with custom fields

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/fragments/PhoneAuthenticationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/PhoneAuthenticationFragment.kt
@@ -1,14 +1,11 @@
 package `in`.testpress.testpress.ui.fragments
 
 import `in`.testpress.enums.Status
-import `in`.testpress.testpress.BuildConfig
 import `in`.testpress.testpress.Injector
 import `in`.testpress.testpress.R
 import `in`.testpress.testpress.core.TestpressService
-import `in`.testpress.testpress.enums.VerificationMethod
 import `in`.testpress.testpress.models.InstituteSettings
 import `in`.testpress.testpress.repository.InstituteRepository
-import `in`.testpress.testpress.ui.WebViewActivity
 import `in`.testpress.testpress.util.UIUtils
 import `in`.testpress.testpress.util.isEmpty
 import `in`.testpress.testpress.viewmodel.LoginViewModel
@@ -16,7 +13,6 @@ import `in`.testpress.util.ViewUtils
 import android.content.Intent
 import android.content.IntentSender
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -106,9 +102,6 @@ class PhoneAuthenticationFragment: BaseAuthenticationFragment() {
     }
 
     private fun showOrHideButtons() {
-        if (!instituteSettings.allowSignup) {
-            signUp.visibility = View.GONE
-        }
         ViewUtils.setGone(userNameLogin, 1 !in instituteSettings.allowedLoginMethods)
         ViewUtils.setGone(facebookSignIn, !instituteSettings.facebookLoginEnabled)
         ViewUtils.setGone(googleSignIn, !instituteSettings.googleLoginEnabled)
@@ -135,13 +128,6 @@ class PhoneAuthenticationFragment: BaseAuthenticationFragment() {
             loginNavigation?.signInWithGoogle()
         }
 
-        signUp.setOnClickListener {
-            val intent = Intent(requireContext(), WebViewActivity::class.java)
-            intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Register")
-            intent.putExtra(WebViewActivity.SHOW_LOGOUT, "false")
-            intent.putExtra(WebViewActivity.URL_TO_OPEN, BuildConfig.BASE_URL + "/register/")
-            startActivity(intent)
-        }
     }
 
     private fun requestOTP(phoneNumber: String, countryCode: String) {

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
@@ -129,11 +129,16 @@ class UsernameAuthentication : BaseAuthenticationFragment() {
         }
 
         signUp.setOnClickListener {
-            val intent = Intent(requireContext(), WebViewActivity::class.java)
-            intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Register")
-            intent.putExtra(WebViewActivity.SHOW_LOGOUT, "false")
-            intent.putExtra(WebViewActivity.URL_TO_OPEN, BuildConfig.BASE_URL + "/register/")
-            startActivity(intent)
+            if (instituteSettings.customRegistrationEnabled){
+                val intent = Intent(requireContext(), WebViewActivity::class.java)
+                intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Register")
+                intent.putExtra(WebViewActivity.SHOW_LOGOUT, "false")
+                intent.putExtra(WebViewActivity.URL_TO_OPEN, BuildConfig.BASE_URL + "/register/")
+                startActivity(intent)
+            } else {
+                val intent = Intent(requireContext(), RegisterActivity::class.java)
+                startActivityForResult(intent, LoginActivity.REQUEST_CODE_REGISTER_USER)
+            }
         }
     }
 

--- a/app/src/main/res/layout-h800dp/phone_login_layout.xml
+++ b/app/src/main/res/layout-h800dp/phone_login_layout.xml
@@ -168,23 +168,6 @@
             app:cornerRadius="8dp"
             android:text="Use Username &amp; Password" />
 
-        <com.google.android.material.button.MaterialButton
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/signUp"
-            android:textSize="14sp"
-            android:paddingVertical="15dp"
-            android:textAllCaps="false"
-            android:layout_marginBottom="10dp"
-            android:textStyle="normal"
-            android:fontFamily="@font/inter"
-            style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-            android:backgroundTint="@color/testpress_color_tertiary"
-            app:backgroundTintMode="add"
-            android:elevation="0dp"
-            app:cornerRadius="8dp"
-            android:text="Create Account" />
-
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout-hdpi/phone_login_layout.xml
+++ b/app/src/main/res/layout-hdpi/phone_login_layout.xml
@@ -169,23 +169,6 @@
             app:cornerRadius="8dp"
             android:text="Use Username &amp; Password" />
 
-        <com.google.android.material.button.MaterialButton
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/signUp"
-            android:textSize="14sp"
-            android:paddingVertical="5dp"
-            android:textAllCaps="false"
-            android:layout_marginBottom="10dp"
-            android:textStyle="normal"
-            android:fontFamily="@font/inter"
-            style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-            android:backgroundTint="@color/testpress_color_tertiary"
-            app:backgroundTintMode="add"
-            android:elevation="0dp"
-            app:cornerRadius="8dp"
-            android:text="Create Account" />
-
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/layout-xhdpi/phone_login_layout.xml
+++ b/app/src/main/res/layout-xhdpi/phone_login_layout.xml
@@ -168,23 +168,6 @@
             app:cornerRadius="8dp"
             android:text="Use Username &amp; Password" />
 
-        <com.google.android.material.button.MaterialButton
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:id="@+id/signUp"
-            android:textSize="14sp"
-            android:paddingVertical="15dp"
-            android:textAllCaps="false"
-            android:layout_marginBottom="10dp"
-            android:textStyle="normal"
-            android:fontFamily="@font/inter"
-            android:backgroundTint="@color/testpress_color_tertiary"
-            style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-            app:backgroundTintMode="add"
-            android:elevation="0dp"
-            app:cornerRadius="8dp"
-            android:text="Create Account" />
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/phone_login_layout.xml
+++ b/app/src/main/res/layout/phone_login_layout.xml
@@ -170,23 +170,6 @@
                 app:backgroundTintMode="add"
                 app:cornerRadius="8dp" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/signUp"
-                style="@style/Widget.MaterialComponents.Button.UnelevatedButton"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp"
-                android:backgroundTint="@color/testpress_color_tertiary"
-                android:elevation="0dp"
-                android:fontFamily="@font/inter"
-                android:paddingVertical="15dp"
-                android:text="Create Account"
-                android:textAllCaps="false"
-                android:textSize="14sp"
-                android:textStyle="normal"
-                app:backgroundTintMode="add"
-                app:cornerRadius="8dp" />
-
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
### Changes done
- Remove Create account button in the OTP login screen
- open webView only for user registration with custom fields
- open the registration screen for default user registation
### Reason for change
- WebView opens when the user tries to register, Webview is only for user registration with custom fields

### Stats
- Number of Test Cases - NIL

### Guidelines
- [ ] Have you self reviewed this PR in context to the previous PR feedbacks?
