### PR TITLE
fix: Add expandable notifications

### DIFF
--- a/app/src/main/java/in/testpress/testpress/util/NotificationHelper.java
+++ b/app/src/main/java/in/testpress/testpress/util/NotificationHelper.java
@@ -128,6 +128,8 @@ public class NotificationHelper extends ContextWrapper {
                 .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.mipmap.ic_launcher))
                 .setContentTitle(title)
                 .setContentText(content)
+                .setStyle(new NotificationCompat.BigTextStyle()
+                        .bigText(content))
                 .setAutoCancel(true)
                 .setSound(defaultSoundUri)
                 .setColor(ContextCompat.getColor(getApplicationContext(), R.color.primary))


### PR DESCRIPTION
### Changes done
- Added expandable notifications to show the long content

### Reason for the changes
- If the notification content long we can't able to see the full content

### Stats
- Number of Test Cases - NIL

### Guidelines
- [ ] Have you self reviewed this PR in context to the previous PR feedbacks?
