### PR TITLE
fix: App crash after its open

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -485,10 +485,10 @@ public class MainActivity extends TestpressFragmentActivity {
             }
             initScreen();
             showMainActivityContents();
-            syncVideoWatchedData();
 
             if (isUserAuthenticated) {
                 updateTestpressSession();
+                syncVideoWatchedData();
 
                 if (mInstituteSettings.getForceStudentData()) {
                     checkForForceUserData();


### PR DESCRIPTION
### Reason for the changes
- Previously users could see public posts if user not authenticated (allow_anonymous_user = true)
- At that time we sync offline video data, If offline video data syncing needs testpressSession
- TestpressSession will create after the user login
- This is the reason for this issue

### Changes done
- Now we moved offline video data syncing after UserAuthenticated

### Stats
- Number of Test Cases - NIL

### Guidelines
- [ ] Have you self reviewed this PR in context to the previous PR feedbacks?
