### PR TITLE
fix: Not able hide soft keyboard in otp verification screen

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
@@ -53,7 +53,6 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initializeInputField()
         setOnClickListeners()
     }
 
@@ -117,9 +116,7 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
                 }
             })
         }
-    }
 
-    private fun initializeInputField(){
         otpField.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_DONE){
                 verifyOTP()

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
@@ -15,6 +15,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import kotlinx.android.synthetic.main.otp_verification_layout.*
@@ -51,6 +53,7 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initializeInputField()
         setOnClickListeners()
     }
 
@@ -114,6 +117,23 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
                 }
             })
         }
+    }
+
+    private fun initializeInputField(){
+        otpField.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_DONE){
+                verifyOTP()
+                hideSoftKeyboard()
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    private fun hideSoftKeyboard(){
+        val inputManager= requireActivity().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputManager.hideSoftInputFromWindow(this.view?.windowToken, InputMethodManager.HIDE_NOT_ALWAYS)
     }
 
     fun verifyOTP() {

--- a/app/src/main/res/layout-h800dp/otp_verification_layout.xml
+++ b/app/src/main/res/layout-h800dp/otp_verification_layout.xml
@@ -101,7 +101,7 @@
                 android:paddingLeft="10dp"
                 android:textColorHint="#aaaaaa"
                 android:background="@android:color/transparent"
-                android:imeOptions="actionNext"
+                android:imeOptions="actionDone"
                 android:textColor="@color/white"
                 android:hint="Enter OTP" />
 

--- a/app/src/main/res/layout-hdpi/otp_verification_layout.xml
+++ b/app/src/main/res/layout-hdpi/otp_verification_layout.xml
@@ -119,7 +119,7 @@
                     android:paddingLeft="10dp"
                     android:textColorHint="#aaaaaa"
                     android:background="@android:color/transparent"
-                    android:imeOptions="actionNext"
+                    android:imeOptions="actionDone"
                     android:textColor="@color/white"
                     android:hint="Enter OTP" />
 

--- a/app/src/main/res/layout-xhdpi/otp_verification_layout.xml
+++ b/app/src/main/res/layout-xhdpi/otp_verification_layout.xml
@@ -101,7 +101,7 @@
                 android:paddingLeft="10dp"
                 android:textColorHint="#aaaaaa"
                 android:background="@android:color/transparent"
-                android:imeOptions="actionNext"
+                android:imeOptions="actionDone"
                 android:textColor="@color/white"
                 android:hint="Enter OTP" />
 

--- a/app/src/main/res/layout/otp_verification_layout.xml
+++ b/app/src/main/res/layout/otp_verification_layout.xml
@@ -101,7 +101,7 @@
                 android:paddingLeft="10dp"
                 android:textColorHint="#aaaaaa"
                 android:background="@android:color/transparent"
-                android:imeOptions="actionNext"
+                android:imeOptions="actionDone"
                 android:textColor="@color/white"
                 android:hint="Enter OTP" />
 


### PR DESCRIPTION
### Changes done
- added action listener for otpFiled
- Add hide soft keyboard

### Reason for the changes
- This issue is already fixed in this commit https://github.com/testpress/android/commit/9e01ea1c0c948c92735f2c1ed5b4676c4c6bcc4d
-  We missed this otp verification screen

### Stats
- Number of Test Cases - NIL

### Guidelines
- [ ] Have you self reviewed this PR in context to the previous PR feedbacks?
