### PR TITLE
fix: Remove usage of Address in profile detail view

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
@@ -221,7 +221,7 @@ public class ProfileDetailsActivity extends BaseAuthenticatedActivity
         handleDetail(dateOfBirth, dobRow, profileDetails.getBirthDate());
 //        String fullAddress = profileDetails.getAddress1() + "\n" + profileDetails.getAddress2()
 //                + "\n" + profileDetails.getCity() + " - " + profileDetails.getZip();
-        //handleDetail(address, addressRow, fullAddress);
+//        handleDetail(address, addressRow, fullAddress);
         handleDetail(city, cityRow, profileDetails.getCity());
         handleDetail(state, stateRow, profileDetails.getState());
         handleDetail(pinCode, pinCodeRow, profileDetails.getZip());

--- a/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
@@ -219,9 +219,9 @@ public class ProfileDetailsActivity extends BaseAuthenticatedActivity
         handleDetail(phone, mobileNoRow, profileDetails.getPhone());
         handleDetail(gender, genderRow, profileDetails.getGender());
         handleDetail(dateOfBirth, dobRow, profileDetails.getBirthDate());
-        String fullAddress = profileDetails.getAddress1() + "\n" + profileDetails.getAddress2()
-                + "\n" + profileDetails.getCity() + " - " + profileDetails.getZip();
-        handleDetail(address, addressRow, fullAddress);
+//        String fullAddress = profileDetails.getAddress1() + "\n" + profileDetails.getAddress2()
+//                + "\n" + profileDetails.getCity() + " - " + profileDetails.getZip();
+        //handleDetail(address, addressRow, fullAddress);
         handleDetail(city, cityRow, profileDetails.getCity());
         handleDetail(state, stateRow, profileDetails.getState());
         handleDetail(pinCode, pinCodeRow, profileDetails.getZip());

--- a/app/src/main/res/layout/profile_detail_layout.xml
+++ b/app/src/main/res/layout/profile_detail_layout.xml
@@ -232,6 +232,7 @@
                 android:layout_marginEnd="@dimen/editor_delete_button_width"
                 android:layout_marginBottom="@dimen/editor_padding_between_read_only_editor_views"
                 android:paddingBottom="20dp"
+                android:visibility="gone"
                 android:id="@+id/address_container"
                 android:orientation="horizontal">
 


### PR DESCRIPTION
- As the ProfileDetails API no longer provides the address value, we are disabling the use of address by commenting out the corresponding code for setting the address and the layout in the view.