### PR TITLE
fix: Dates not visible in Date picker

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -225,7 +225,7 @@
 
         <activity
             android:name=".ui.WebViewActivity"
-            android:theme="@style/AppTheme"
+            android:theme="@style/TestpressWebViewTheme"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="Web View" />
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -113,6 +113,17 @@
         <item name="android:textAppearanceLargePopupMenu">@style/popupMenuTextAppearance</item>
     </style>
 
+    <style name="TestpressWebViewTheme" parent="Theme.MaterialComponents.Light.DarkActionBar.Bridge">
+        <item name="colorPrimary">@color/primary</item>
+        <item name="colorAccent">@color/primary</item>
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
+        <item name="colorControlNormal">@color/white</item>
+        <item name="colorButtonNormal">@color/primary</item>
+        <item name="android:statusBarColor">@color/primary</item>
+        <item name="android:textAppearanceLargePopupMenu">@style/popupMenuTextAppearance</item>
+    </style>
+
     <style name="popupMenuTextAppearance" parent="@android:style/TextAppearance.DeviceDefault.Widget.PopupMenu.Large">
         <item name="android:textColor">@color/testpress_black</item>
     </style>


### PR DESCRIPTION
- We use the same theme for all activities with the default text color white.
- This is applicable for Date pickers also but here Date picker's background is white and the text is also white so the text is not visible.
- In this commit, we created a separate theme for webview activity with the default text color.