### PR TITLE
fix: Change Banner ad resolution to 1500x600 in Dashboard

### DIFF
--- a/app/src/main/res/layout/offers_carousel_item.xml
+++ b/app/src/main/res/layout/offers_carousel_item.xml
@@ -9,8 +9,8 @@
 
     <in.testpress.testpress.ui.view.RoundedCornerImageView
         android:id="@+id/image_view"
-        android:layout_width="320dp"
-        android:layout_height="180dp"
+        android:layout_width="375dp"
+        android:layout_height="125dp"
         android:tint="#000000"
         android:scaleType="centerCrop"
         android:background="@drawable/border_rectangle_light"

--- a/app/src/main/res/layout/offers_carousel_item.xml
+++ b/app/src/main/res/layout/offers_carousel_item.xml
@@ -10,7 +10,7 @@
     <in.testpress.testpress.ui.view.RoundedCornerImageView
         android:id="@+id/image_view"
         android:layout_width="375dp"
-        android:layout_height="125dp"
+        android:layout_height="150dp"
         android:tint="#000000"
         android:scaleType="centerCrop"
         android:background="@drawable/border_rectangle_light"


### PR DESCRIPTION
- Recently we enforced the banner size as 1500x600 for the new landing page on the web.
- in this commit, the banner ad size is changed to 375x150 which is equivalent to 1500x600.