### PR TITLE
fix: Expose current payment app in app config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -177,6 +177,13 @@ android {
             resValue "string", "white_labeled_host_url", json.white_labeled_host_url
             buildConfigField "String", "WHITE_LABELED_HOST_URL", '"https://' + json.white_labeled_host_url + '"'
         }
+        if (json.current_payment_app == null) {
+            resValue "string", "current_payment_app", ""
+            buildConfigField "String", "CURRENT_PAYMENT_APP", '""'
+        } else {
+            resValue "string", "current_payment_app", json.current_payment_app
+            buildConfigField "String", "CURRENT_PAYMENT_APP", '"' + json.current_payment_app + '"'
+        }
         buildConfigField "boolean", "ZOOM_CUSTOM_MEETING_UI_ENABLED", "" + json.zoom_custom_meeting_ui_enabled
 
         applicationId json.package_name

--- a/app/src/main/assets/config.json
+++ b/app/src/main/assets/config.json
@@ -16,5 +16,6 @@
   "is_growth_hacks_enabled": false,
   "show_pdf_vertically": true,
   "zoom_enabled": false,
-  "zoom_custom_meeting_ui_enabled": false
+  "zoom_custom_meeting_ui_enabled": false,
+  "current_payment_app": null
 }

--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -43,6 +43,7 @@ import static in.testpress.testpress.BuildConfig.SHOW_PDF_VERTICALLY;
 import static in.testpress.testpress.BuildConfig.GROWTH_HACKS_ENABLED;
 import static in.testpress.testpress.BuildConfig.SHARE_MESSAGE;
 import static in.testpress.testpress.BuildConfig.ZOOM_CUSTOM_MEETING_UI_ENABLED;
+import static in.testpress.testpress.BuildConfig.CURRENT_PAYMENT_APP;
 import static in.testpress.testpress.util.PreferenceManager.setDashboardData;
 
 public class TestpressServiceProvider {
@@ -112,6 +113,7 @@ public class TestpressServiceProvider {
                 InstituteSettings instituteSettings = instituteSettingsList.get(0);
                 settings = new in.testpress.models.InstituteSettings(instituteSettings.getBaseUrl())
                         .setWhiteLabeledHostUrl(BuildConfig.WHITE_LABELED_HOST_URL)
+                        .setCurrentPaymentApp(CURRENT_PAYMENT_APP)
                         .setBookmarksEnabled(instituteSettings.getBookmarksEnabled())
                         .setCoursesFrontend(instituteSettings.getShowGameFrontend())
                         .setCoursesGamificationEnabled(instituteSettings.getCoursesEnableGamification())


### PR DESCRIPTION
### Changes done
- We recently integrated Razorpay in SDK in commit
https://github.com/testpress/android-sdk/commit/56a3dc16b24a1f67c09c23533374bfafde358c38.
- This commit exposes `current_payment_app` required in the
integration to decide which payment gateway to use.

### Reason for the changes
- 
- 

Fixes # . **Remove this line if there aren't any corresponding issues created**

### Stats
- Number of Test Cases - 

### Guidelines
- [x] Have you self reviewed this PR in context to the previous PR feedbacks?
