### PR TITLE
refactor: ViewLifecycleOwner object in OTPVerificationFragment

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
@@ -139,7 +139,7 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
             return
         }
         requireActivity().runOnUiThread {
-            viewModel.verifyOTP(Integer.parseInt(otpField.text.toString()), phoneNumber).observe(this, { resource ->
+            viewModel.verifyOTP(Integer.parseInt(otpField.text.toString()), phoneNumber).observe(viewLifecycleOwner, { resource ->
                 when(resource.status) {
                     Status.SUCCESS -> {
                         if (resource.data?.token != null) {


### PR DESCRIPTION
- We provided fragment object to life cycle observe
- In this commit, We passed ViewLifecycleOwner object to life cycle observe because observe required ViewLifecycleOwner object
