### PR TITLE
fix: Add currentPaymentApp field in InstituteSettings Model

### DIFF
--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -43,7 +43,6 @@ import static in.testpress.testpress.BuildConfig.SHOW_PDF_VERTICALLY;
 import static in.testpress.testpress.BuildConfig.GROWTH_HACKS_ENABLED;
 import static in.testpress.testpress.BuildConfig.SHARE_MESSAGE;
 import static in.testpress.testpress.BuildConfig.ZOOM_CUSTOM_MEETING_UI_ENABLED;
-import static in.testpress.testpress.BuildConfig.CURRENT_PAYMENT_APP;
 import static in.testpress.testpress.util.PreferenceManager.setDashboardData;
 
 public class TestpressServiceProvider {
@@ -113,7 +112,7 @@ public class TestpressServiceProvider {
                 InstituteSettings instituteSettings = instituteSettingsList.get(0);
                 settings = new in.testpress.models.InstituteSettings(instituteSettings.getBaseUrl())
                         .setWhiteLabeledHostUrl(BuildConfig.WHITE_LABELED_HOST_URL)
-                        .setCurrentPaymentApp(CURRENT_PAYMENT_APP)
+                        .setCurrentPaymentApp(instituteSettings.getCurrentPaymentApp())
                         .setBookmarksEnabled(instituteSettings.getBookmarksEnabled())
                         .setCoursesFrontend(instituteSettings.getShowGameFrontend())
                         .setCoursesGamificationEnabled(instituteSettings.getCoursesEnableGamification())

--- a/app/src/main/java/in/testpress/testpress/models/InstituteSettings.java
+++ b/app/src/main/java/in/testpress/testpress/models/InstituteSettings.java
@@ -74,6 +74,7 @@ public class InstituteSettings {
     private Boolean disableForgotPassword;
     private Boolean disableStudentReport;
     private Boolean enableCustomTest;
+    private String currentPaymentApp;
 
     // KEEP FIELDS - put your custom fields here
     // KEEP FIELDS END
@@ -85,7 +86,7 @@ public class InstituteSettings {
         this.baseUrl = baseUrl;
     }
 
-    public InstituteSettings(String baseUrl, String verificationMethod, Boolean allowSignup, Boolean forceStudentData, Boolean removeTpBranding, String url, Boolean showGameFrontend, Boolean coursesEnabled, Boolean coursesEnableGamification, String coursesLabel, Boolean postsEnabled, String postsLabel, Boolean storeEnabled, String storeLabel, Boolean documentsEnabled, String documentsLabel, Boolean resultsEnabled, Boolean dashboardEnabled, Boolean facebookLoginEnabled, Boolean googleLoginEnabled, boolean commentsVotingEnabled, Boolean bookmarksEnabled, Boolean forumEnabled, Boolean twilioEnabled, Boolean allow_profile_edit, String learnLabel, String leaderboardLabel, String dashboardLabel, String bookmarksLabel, String loginLabel, String loginPasswordLabel, String aboutUs, Boolean disableStudentAnalytics, Boolean customRegistrationEnabled, Boolean enableParallelLoginRestriction, Integer maxParallelLogins, Integer lockoutLimit, String cooloffTime, String appToolbarLogo, String appShareLink, String serverTime, Boolean allowScreenshotInApp, String androidSentryDns, Boolean leaderboardEnabled, String threatsAndTargetsLabel, Boolean isVideoDownloadEnabled, Boolean isHelpdeskEnabled, IntegerList allowedLoginMethods, Boolean showShareButton, String facebookAppId, Integer maxAllowedDownloadedVideos, Boolean disableForgotPassword, Boolean disableStudentReport, Boolean enableCustomTest) {
+    public InstituteSettings(String baseUrl, String verificationMethod, Boolean allowSignup, Boolean forceStudentData, Boolean removeTpBranding, String url, Boolean showGameFrontend, Boolean coursesEnabled, Boolean coursesEnableGamification, String coursesLabel, Boolean postsEnabled, String postsLabel, Boolean storeEnabled, String storeLabel, Boolean documentsEnabled, String documentsLabel, Boolean resultsEnabled, Boolean dashboardEnabled, Boolean facebookLoginEnabled, Boolean googleLoginEnabled, boolean commentsVotingEnabled, Boolean bookmarksEnabled, Boolean forumEnabled, Boolean twilioEnabled, Boolean allow_profile_edit, String learnLabel, String leaderboardLabel, String dashboardLabel, String bookmarksLabel, String loginLabel, String loginPasswordLabel, String aboutUs, Boolean disableStudentAnalytics, Boolean customRegistrationEnabled, Boolean enableParallelLoginRestriction, Integer maxParallelLogins, Integer lockoutLimit, String cooloffTime, String appToolbarLogo, String appShareLink, String serverTime, Boolean allowScreenshotInApp, String androidSentryDns, Boolean leaderboardEnabled, String threatsAndTargetsLabel, Boolean isVideoDownloadEnabled, Boolean isHelpdeskEnabled, IntegerList allowedLoginMethods, Boolean showShareButton, String facebookAppId, Integer maxAllowedDownloadedVideos, Boolean disableForgotPassword, Boolean disableStudentReport, Boolean enableCustomTest, String currentPaymentApp) {
         this.baseUrl = baseUrl;
         this.verificationMethod = verificationMethod;
         this.allowSignup = allowSignup;
@@ -140,6 +141,7 @@ public class InstituteSettings {
         this.disableForgotPassword = disableForgotPassword;
         this.disableStudentReport = disableStudentReport;
         this.enableCustomTest = enableCustomTest;
+        this.currentPaymentApp = currentPaymentApp;
     }
 
     public String getBaseUrl() {
@@ -572,6 +574,14 @@ public class InstituteSettings {
 
     public void setEnableCustomTest(Boolean enableCustomTest) {
         this.enableCustomTest = enableCustomTest;
+    }
+
+    public String getCurrentPaymentApp() {
+        return currentPaymentApp;
+    }
+
+    public void setCurrentPaymentApp(String currentPaymentApp) {
+        this.currentPaymentApp = currentPaymentApp;
     }
 
     // KEEP METHODS - put your custom methods here

--- a/app/src/main/java/in/testpress/testpress/models/InstituteSettingsDao.java
+++ b/app/src/main/java/in/testpress/testpress/models/InstituteSettingsDao.java
@@ -80,6 +80,7 @@ public class InstituteSettingsDao extends AbstractDao<InstituteSettings, String>
         public final static Property DisableForgotPassword = new Property(51, Boolean.class, "disableForgotPassword", false, "DISABLE_FORGOT_PASSWORD");
         public final static Property DisableStudentReport = new Property(52, Boolean.class, "disableStudentReport", false, "DISABLE_STUDENT_REPORT");
         public final static Property EnableCustomTest = new Property(53, Boolean.class, "enableCustomTest", false, "ENABLE_CUSTOM_TEST");
+        public final static Property CurrentPaymentApp = new Property(54, String.class, "currentPaymentApp", false, "CURRENT_PAYMENT_APP");
     };
 
     private final IntegerListConverter allowedLoginMethodsConverter = new IntegerListConverter();
@@ -149,7 +150,8 @@ public class InstituteSettingsDao extends AbstractDao<InstituteSettings, String>
                 "\"MAX_ALLOWED_DOWNLOADED_VIDEOS\" INTEGER," + // 50: maxAllowedDownloadedVideos
                 "\"DISABLE_FORGOT_PASSWORD\" INTEGER," + // 51: disableForgotPassword
                 "\"DISABLE_STUDENT_REPORT\" INTEGER," + // 52: disableStudentReport
-                "\"ENABLE_CUSTOM_TEST\" INTEGER);"); // 53: enableCustomTest
+                "\"ENABLE_CUSTOM_TEST\" INTEGER," + // 53: enableCustomTest
+                "\"CURRENT_PAYMENT_APP\" TEXT);"); // 54: currentPaymentApp
     }
 
     /** Drops the underlying database table. */
@@ -428,6 +430,11 @@ public class InstituteSettingsDao extends AbstractDao<InstituteSettings, String>
         if (enableCustomTest != null) {
             stmt.bindLong(54, enableCustomTest ? 1L: 0L);
         }
+ 
+        String currentPaymentApp = entity.getCurrentPaymentApp();
+        if (currentPaymentApp != null) {
+            stmt.bindString(55, currentPaymentApp);
+        }
     }
 
     /** @inheritdoc */
@@ -493,7 +500,8 @@ public class InstituteSettingsDao extends AbstractDao<InstituteSettings, String>
             cursor.isNull(offset + 50) ? null : cursor.getInt(offset + 50), // maxAllowedDownloadedVideos
             cursor.isNull(offset + 51) ? null : cursor.getShort(offset + 51) != 0, // disableForgotPassword
             cursor.isNull(offset + 52) ? null : cursor.getShort(offset + 52) != 0, // disableStudentReport
-            cursor.isNull(offset + 53) ? null : cursor.getShort(offset + 53) != 0 // enableCustomTest
+            cursor.isNull(offset + 53) ? null : cursor.getShort(offset + 53) != 0, // enableCustomTest
+            cursor.isNull(offset + 54) ? null : cursor.getString(offset + 54) // currentPaymentApp
         );
         return entity;
     }
@@ -555,6 +563,7 @@ public class InstituteSettingsDao extends AbstractDao<InstituteSettings, String>
         entity.setDisableForgotPassword(cursor.isNull(offset + 51) ? null : cursor.getShort(offset + 51) != 0);
         entity.setDisableStudentReport(cursor.isNull(offset + 52) ? null : cursor.getShort(offset + 52) != 0);
         entity.setEnableCustomTest(cursor.isNull(offset + 53) ? null : cursor.getShort(offset + 53) != 0);
+        entity.setCurrentPaymentApp(cursor.isNull(offset + 54) ? null : cursor.getString(offset + 54));
      }
     
     /** @inheritdoc */

--- a/testpressdaogenerator/src/main/java/in/testpress/testpress/TestpressDaoGenerator.java
+++ b/testpressdaogenerator/src/main/java/in/testpress/testpress/TestpressDaoGenerator.java
@@ -99,6 +99,7 @@ public class TestpressDaoGenerator {
         instituteSettings.addBooleanProperty("disableForgotPassword");
         instituteSettings.addBooleanProperty("disableStudentReport");
         instituteSettings.addBooleanProperty("enableCustomTest");
+        instituteSettings.addStringProperty("currentPaymentApp");
 
         Entity rssFeed = schema.addEntity("RssItem");
         rssFeed.addLongProperty("id").primaryKey().autoincrement();


### PR DESCRIPTION
- Previously we added the currentPaymentApp field in config.json. This is not the right way because every time we need to release an update if we change the payment App.
- In this commit, Added the enableCustomTest field in the InstituteSettings Model.
- Set the enableCustomTest field in SDK InstituteSettings.