### PR TITLE
fix: Ask Notification permission after user login

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -326,6 +326,7 @@ public class MainActivity extends TestpressFragmentActivity {
                 if (viewPager.getVisibility() != View.VISIBLE) {
                     initScreen();
                 }
+                askNotificationPermission();
             }
         }.execute();
     }
@@ -699,7 +700,6 @@ public class MainActivity extends TestpressFragmentActivity {
             viewPager.setVisibility(View.VISIBLE);
             grid.setVisibility(View.VISIBLE);
         }
-        askNotificationPermission();
     }
 
     private void askNotificationPermission() {


### PR DESCRIPTION
- In this commit d3e8cc5 we add Ask Notification permission to the user in MainActivity so that the notification permission popup launches before the LoginActivity shows
- Now in this commit, we ask for notification permission to the user after the user made a successful login.
