### PR TITLE
fix: Hide post and student report button before user login

### DIFF
--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -31,11 +31,13 @@
             android:id="@+id/doubts"
             android:title="Doubts"
             android:icon="@drawable/ic_baseline_message_24"
+            android:visible="false"
             app:showAsAction="never"/>
         <item
             android:id="@+id/student_report"
             android:title="Your Report"
             android:icon="@drawable/ic_student_report"
+            android:visible="false"
             app:showAsAction="never"/>
         <item
             android:id="@+id/logout"


### PR DESCRIPTION
- In this commit, we initially hide the post and student report buttons in the NavigationDrawer for anonymous users. These features require user login, and after the user logs in, we validate their access based on the institution's settings.
