### PR TITLE
fix: Update Android minimum SDK version to 23

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -144,7 +144,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 33
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
- In this commit, we're increasing the minimum SDK version to 23. This change is necessary because we're incorporating the Zoom SDK into our app, and for this release, we need to update the Zoom SDK version to 5.13.5.11583. It's important to note that in this release, the minimum SDK version required by the Zoom SDK has been raised to 23, so we are aligning our app's requirements accordingly.
