### PR TITLE
fix: Handled BackPress for custom store webview in MainActivity

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -153,7 +153,11 @@ public class MainActivity extends TestpressFragmentActivity {
 
     @Override
     public void onBackPressed() {
-        if (viewPager.getCurrentItem() != 0) {
+        if (courseListFragment != null && viewPager.getCurrentItem() == 1) {
+            if (courseListFragment.onBackPress()) {
+                viewPager.setCurrentItem(0);
+            }
+        } else if (viewPager.getCurrentItem() != 0) {
             viewPager.setCurrentItem(0);
         } else {
             super.onBackPressed();


### PR DESCRIPTION
- We've just integrated a custom store WebView into the Android SDK project, which means we now have to implement stack-back functionality for this custom WebView within the MainActivity of our app.