### PR TITLE
fix: App not build if app name contains single quotes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,6 +155,7 @@ android {
         resValue "string", "host_url", host_url
         buildConfigField "String", "BASE_URL", '"https://' + host_url + '"'
         resValue "string", "app_name", json.app_name
+        println(json.app_name)
         resValue "string", "version", "v " + json.version
         resValue "string", "share_message", json.share_message
         resValue "string", "facebook_app_id", json.facebook_app_id

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,7 +155,6 @@ android {
         resValue "string", "host_url", host_url
         buildConfigField "String", "BASE_URL", '"https://' + host_url + '"'
         resValue "string", "app_name", json.app_name
-        println(json.app_name)
         resValue "string", "version", "v " + json.version
         resValue "string", "share_message", json.share_message
         resValue "string", "facebook_app_id", json.facebook_app_id

--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -37,7 +37,7 @@ module Fastlane
                 if key == "app_name"
                     temp_app_name = app_config_json[key]
                     # Replace single quotes with escaped single quotes
-                    config_json[key] = temp_app_name..gsub("\'", "\\\\'")
+                    config_json[key] = temp_app_name.gsub("\'", "\\\\'")
                 else
                     config_json[key] = app_config_json[key]
                 end

--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -36,8 +36,7 @@ module Fastlane
             if app_config_json.key?(key) && fields.include?(key)
                 if key == "app_name"
                     temp_app_name = app_config_json[key]
-                    # Replace single quotes with escaped single quotes
-                    config_json[key] = temp_app_name.gsub("\'", "\\\\'")
+                    config_json[key] = sanitize_app_name(temp_app_name)
                 else
                     config_json[key] = app_config_json[key]
                 end
@@ -51,6 +50,11 @@ module Fastlane
         [
            FastlaneCore::ConfigItem.new(key: :config_json, description: "Json file with value to update")
         ]
+      end
+      def self.sanitize_app_name(app_name)
+        # Replace single quotes with escaped single quotes
+        sanitized_name = app_name.gsub("\'", "\\\\'")
+        return sanitized_name
       end
     end
   end

--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -36,7 +36,9 @@ module Fastlane
             if app_config_json.key?(key) && fields.include?(key)
                 if key == "app_name"
                     temp_app_name = app_config_json[key]
+                    puts temp_app_name
                     config_json[key] = sanitize_app_name(temp_app_name)
+                    puts config_json[key]
                 else
                     config_json[key] = app_config_json[key]
                 end

--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -34,12 +34,9 @@ module Fastlane
           app_config_json = JSON.parse(data)
           config_json.each do |key, value|
             if app_config_json.key?(key) && fields.include?(key)
-                puts key
                 if key == "app_name"
                     temp_app_name = app_config_json[key]
-                    puts temp_app_name
                     config_json[key] = sanitize_app_name(temp_app_name)
-                    puts config_json[key]
                 else
                     config_json[key] = app_config_json[key]
                 end
@@ -54,7 +51,7 @@ module Fastlane
            FastlaneCore::ConfigItem.new(key: :config_json, description: "Json file with value to update")
         ]
       end
-      def sanitize_app_name(app_name)
+      def self.sanitize_app_name(app_name)
         # Replace single quotes with escaped single quotes
         sanitized_name = app_name.gsub("\'", "\\\\'")
         return sanitized_name

--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -36,7 +36,8 @@ module Fastlane
             if app_config_json.key?(key) && fields.include?(key)
                 if key == "app_name"
                     temp_app_name = app_config_json[key]
-                    config_json[key] = sanitize_app_name(temp_app_name)
+                    # Replace single quotes with escaped single quotes
+                    config_json[key] = temp_app_name..gsub("\'", "\\\\'")
                 else
                     config_json[key] = app_config_json[key]
                 end
@@ -50,11 +51,6 @@ module Fastlane
         [
            FastlaneCore::ConfigItem.new(key: :config_json, description: "Json file with value to update")
         ]
-      end
-      def self.sanitize_app_name(app_name)
-        # Replace single quotes with escaped single quotes
-        sanitized_name = app_name.gsub("\'", "\\\\'")
-        return sanitized_name
       end
     end
   end

--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -56,7 +56,7 @@ module Fastlane
       end
       def sanitize_app_name(app_name)
         # Replace single quotes with escaped single quotes
-        sanitized_name = app_name.gsub("'", "\\\\'")
+        sanitized_name = app_name.gsub("\'", "\\\\'")
         return sanitized_name
       end
     end

--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -34,7 +34,12 @@ module Fastlane
           app_config_json = JSON.parse(data)
           config_json.each do |key, value|
             if app_config_json.key?(key) && fields.include?(key)
-                config_json[key] = app_config_json[key]
+                if key == "app_name"
+                    temp_app_name = app_config_json[key]
+                    config_json[key] = sanitize_app_name(temp_app_name)
+                else
+                    config_json[key] = app_config_json[key]
+                end
             end
           end
           File.open(path,"w") do |f|
@@ -45,6 +50,11 @@ module Fastlane
         [
            FastlaneCore::ConfigItem.new(key: :config_json, description: "Json file with value to update")
         ]
+      end
+      def sanitize_app_name(app_name)
+        # Replace single quotes with escaped single quotes
+        sanitized_name = app_name.gsub("'", "\\\\'")
+        return sanitized_name
       end
     end
   end

--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -36,7 +36,8 @@ module Fastlane
             if app_config_json.key?(key) && fields.include?(key)
                 if key == "app_name"
                     temp_app_name = app_config_json[key]
-                    config_json[key] = sanitize_app_name(temp_app_name)
+                    # Replace single quotes with escaped single quotes
+                    config_json[key] = temp_app_name.gsub("\'", "\\\\'")
                 else
                     config_json[key] = app_config_json[key]
                 end
@@ -50,11 +51,6 @@ module Fastlane
         [
            FastlaneCore::ConfigItem.new(key: :config_json, description: "Json file with value to update")
         ]
-      end
-      def self.sanitize_app_name(app_name)
-        # Replace single quotes with escaped single quotes
-        sanitized_name = app_name.gsub("\'", "\\\\'")
-        return sanitized_name
       end
     end
   end

--- a/fastlane/actions/modify_config_json_file.rb
+++ b/fastlane/actions/modify_config_json_file.rb
@@ -34,6 +34,7 @@ module Fastlane
           app_config_json = JSON.parse(data)
           config_json.each do |key, value|
             if app_config_json.key?(key) && fields.include?(key)
+                puts key
                 if key == "app_name"
                     temp_app_name = app_config_json[key]
                     puts temp_app_name


### PR DESCRIPTION
- In our Android app, we save the app_name in an XML file. However, Android XML resource files do not support single quotes.
- In this commit, we sanitize the `app_name` in before generating the `config.json` file
