### PR TITLE
fix: Use Testpress SDK version 1.4.128

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 ext {
-    testpressSDK = '1.4.127'
+    testpressSDK = '1.4.128'
 }
 
 def jsonFile = file('src/main/assets/config.json')

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/DiscussionFragmentv2.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/DiscussionFragmentv2.kt
@@ -21,7 +21,6 @@ class DiscussionFragmentv2: DiscussionFragment() {
         requireActivity().startActivity(intent)
     }
 
-    @ExperimentalPagingApi
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         viewModel.categories.observe(viewLifecycleOwner, Observer { domainCategories ->


### PR DESCRIPTION
- In this commit, we used Testpress android SDK version `1.4.127` to `1.4.128`.
- We removed the ExperimentalPagingApi annotation in the `DiscussionFragment` within the Android SDK project. Since `DiscussionFragmentv2` is a subclass of `DiscussionFragment`, we are applying the same modification to it.