### PR TITLE
enhancement: Use `viewBinding` instead of `kotlin-android-extensions` in EmailVerificationFragment

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/fragments/EmailVerificationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/EmailVerificationFragment.kt
@@ -10,8 +10,6 @@ import androidx.lifecycle.Observer
 
 open class EmailVerificationFragment : RegistrationBaseFragment() {
 
-
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setOnClickListener()

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/EmailVerificationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/EmailVerificationFragment.kt
@@ -7,10 +7,10 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Observer
-import kotlinx.android.synthetic.main.register_activity.*
-import kotlinx.android.synthetic.main.success_message_layout.*
 
 open class EmailVerificationFragment : RegistrationBaseFragment() {
+
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -41,13 +41,13 @@ open class EmailVerificationFragment : RegistrationBaseFragment() {
 
     private fun showVerifyEmailLayout() {
         ProgressUtil.progressDialog.dismiss()
-        registerLayout.visibility = View.GONE
-        success_description.setText(R.string.activation_email_sent_message)
-        success_complete.visibility = View.VISIBLE
+        binding.registerLayout.visibility = View.GONE
+        binding.successMessageLayout!!.successDescription.setText(R.string.activation_email_sent_message)
+        binding.successMessageLayout!!.successComplete.visibility = View.VISIBLE
     }
 
     private fun setOnClickListener() {
-        success_ok.setOnClickListener {
+        binding.successMessageLayout!!.successOk.setOnClickListener {
             activity.finish()
         }
     }

--- a/app/src/main/res/layout/register_activity.xml
+++ b/app/src/main/res/layout/register_activity.xml
@@ -18,7 +18,9 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <include layout="@layout/success_message_layout" />
+            <include
+                android:id="@+id/success_message_layout"
+                layout="@layout/success_message_layout" />
 
             <LinearLayout
                 android:id="@+id/registerLayout"


### PR DESCRIPTION
- `kotlin-android-extensions` is depreciated so we are migrating to `viewbinding`  [Docs](https://goo.gle/kotlin-android-extensions-deprecation)
- In this commit, we replaced `viewBinding` instead of `kotlin-android-extensions` in EmailVerificationFragment

