### PR TITLE
enhancement: Use `viewBinding` instead of `kotlin-android-extensions` in OTPVerificationFragment

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
@@ -2,8 +2,8 @@ package `in`.testpress.testpress.ui.fragments
 
 import `in`.testpress.enums.Status
 import `in`.testpress.testpress.Injector
-import `in`.testpress.testpress.R
 import `in`.testpress.testpress.core.TestpressService
+import `in`.testpress.testpress.databinding.OtpVerificationLayoutBinding
 import `in`.testpress.testpress.repository.InstituteRepository
 import `in`.testpress.testpress.ui.utils.AutoDetectOTP
 import `in`.testpress.testpress.util.UIUtils
@@ -19,7 +19,6 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import kotlinx.android.synthetic.main.otp_verification_layout.*
 import java.util.*
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -33,6 +32,8 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
     lateinit var testPressService: TestpressService
     lateinit var phoneNumber: String
     lateinit var countryCode: String
+    private var _binding: OtpVerificationLayoutBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -48,7 +49,8 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.otp_verification_layout, container, false)
+        _binding = OtpVerificationLayoutBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -83,7 +85,7 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
                     if (matcher.find()) {
                         val otp = matcher.group(0)
                         if (isVisible) {
-                            otpField.setText(otp)
+                            binding.otpField.setText(otp)
                             Timer().schedule(500) {
                                 verifyOTP()
                             }
@@ -100,15 +102,15 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
     }
 
     fun setOnClickListeners() {
-        verifyOTP.setOnClickListener {
+        binding.verifyOTP.setOnClickListener {
             verifyOTP()
         }
 
-        resentOtp.setOnClickListener {
+        binding.resentOtp.setOnClickListener {
             viewModel.requestOTP(phoneNumber, countryCode).observe(viewLifecycleOwner, { resource ->
                 when(resource.status) {
                     Status.SUCCESS -> {
-                        helpText.text = "We resent your OTP"
+                        binding.helpText?.text = "We resent your OTP"
                     }
                     Status.ERROR -> {
                         UIUtils.showAlert(requireContext(),resource.data?.detail ?: "Couldn't send OTP. Please try again")
@@ -118,7 +120,7 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
             })
         }
 
-        otpField.setOnEditorActionListener { _, actionId, _ ->
+        binding.otpField.setOnEditorActionListener { _, actionId, _ ->
             if (actionId == EditorInfo.IME_ACTION_DONE){
                 verifyOTP()
                 hideSoftKeyboard()
@@ -135,12 +137,12 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
     }
 
     fun verifyOTP() {
-        if (otpField.isEmpty()) {
-            otpField.error = "Please enter OTP number"
+        if (binding.otpField.isEmpty()) {
+            binding.otpField.error = "Please enter OTP number"
             return
         }
         requireActivity().runOnUiThread {
-            viewModel.verifyOTP(Integer.parseInt(otpField.text.toString()), phoneNumber).observe(viewLifecycleOwner, { resource ->
+            viewModel.verifyOTP(Integer.parseInt(binding.otpField.text.toString()), phoneNumber).observe(viewLifecycleOwner, { resource ->
                 when(resource.status) {
                     Status.SUCCESS -> {
                         if (resource.data?.token != null) {
@@ -159,5 +161,10 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
                 }
             })
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 }


### PR DESCRIPTION
- `kotlin-android-extensions` is depreciated so we are migrating to `viewbinding`  [Docs](https://goo.gle/kotlin-android-extensions-deprecation)
- In this commit, we replaced `viewBinding` instead of `kotlin-android-extensions` in OTPVerificationFragment
