### PR TITLE
enhancement: Update Kotlin version to 1.8.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ import groovy.json.JsonSlurper
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.7.0'
+    ext.kotlin_version = '1.8.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
- Updated Kotlin version from `1.7.0` to `1.8.0`.
- Removed `kotlin-android-extensions` as it's deprecated in Kotlin `1.8.0`. See [Docs](https://android-developers.googleblog.com/2022/02/discontinuing-kotlin-synthetics-for-views.html) for more details.