### PR TITLE
fix: Back stack not working on Discussion activity 

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -251,7 +251,7 @@ public class HandleMainMenu {
                         title,
                         "/discussions/new",
                         true,
-                        CustomTestGenerationActivity.class
+                        WebViewWithSSOActivity.class
                 )
         );
     }


### PR DESCRIPTION
- The reason for the back stack not working is due to the usage of CustomTestGenerationActivity to display the Discussion webview. By replacing it with WebViewWithSSOActivity, we can resolve this issue.