### PR TITLE
enhancement: Set androidSentryDns in InstituteSettings of sdk

### DIFF
--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -135,6 +135,7 @@ public class TestpressServiceProvider {
                         .setMaxAllowedDownloadedVideos(instituteSettings.getMaxAllowedDownloadedVideos())
                         .setEnableCustomTest(instituteSettings.getEnableCustomTest())
                         .setStoreEnabled(instituteSettings.getStoreEnabled())
+                        .setAndroidSentryDns(instituteSettings.getAndroidSentryDns())
                         .setDisableStoreInApp(instituteSettings.getDisableStoreInApp());
                 appLink = instituteSettings.getAppShareLink();
             }

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
@@ -1,5 +1,6 @@
 package `in`.testpress.testpress.ui.fragments
 
+import `in`.testpress.core.TestpressSdk
 import `in`.testpress.enums.Status
 import `in`.testpress.testpress.Injector
 import `in`.testpress.testpress.core.TestpressService
@@ -147,6 +148,7 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
                     Status.SUCCESS -> {
                         if (resource.data?.token != null) {
                             loginNavigation?.onLoginSuccess(phoneNumber,"", resource.data!!.token!!)
+                            TestpressSdk.initSentry(requireContext(),testPressService.instituteSettings.androidSentryDns)
                         }
                     }
                     Status.ERROR -> {


### PR DESCRIPTION
- In this commit, we set `androidSentryDns` in InstituteSettings of the SDK.
- To ensure Sentry is not initialized during the OTP login process, we initialize Sentry after the OTP login success.
