### PR TITLE
fix: Set androidSentryDns in InstituteSettings of sdk

### DIFF
--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -135,6 +135,7 @@ public class TestpressServiceProvider {
                         .setMaxAllowedDownloadedVideos(instituteSettings.getMaxAllowedDownloadedVideos())
                         .setEnableCustomTest(instituteSettings.getEnableCustomTest())
                         .setStoreEnabled(instituteSettings.getStoreEnabled())
+                        .setAndroidSentryDns(instituteSettings.getAndroidSentryDns())
                         .setDisableStoreInApp(instituteSettings.getDisableStoreInApp());
                 appLink = instituteSettings.getAppShareLink();
             }

--- a/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
@@ -243,6 +243,7 @@ public class CodeVerificationActivity extends AppCompatActivity {
                         .setBookmarksEnabled(instituteSettings.getBookmarksEnabled())
                         .setCoursesFrontend(instituteSettings.getShowGameFrontend())
                         .setCoursesGamificationEnabled(instituteSettings.getCoursesEnableGamification())
+                        .setAndroidSentryDns(instituteSettings.getAndroidSentryDns())
                         .setCommentsVotingEnabled(instituteSettings.getCommentsVotingEnabled()).setAccessCodeEnabled(false);
 
         TestpressSdk.initialize(this, settings, username, password, TestpressSdk.Provider.TESTPRESS,

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -381,6 +381,7 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
                         .setCoursesFrontend(instituteSettings.getShowGameFrontend())
                         .setCoursesGamificationEnabled(instituteSettings.getCoursesEnableGamification())
                         .setCommentsVotingEnabled(instituteSettings.getCommentsVotingEnabled())
+                        .setAndroidSentryDns(instituteSettings.getAndroidSentryDns())
                         .setAccessCodeEnabled(false);
 
         TestpressSdk.initialize(this, settings, userId, accessToken, provider,

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
@@ -235,6 +235,7 @@ class LoginActivityV2: ActionBarAccountAuthenticatorActivity(), LoginNavigationI
             .setCoursesFrontend(instituteSettings.showGameFrontend)
             .setCoursesGamificationEnabled(instituteSettings.coursesEnableGamification)
             .setCommentsVotingEnabled(instituteSettings.commentsVotingEnabled)
+            .setAndroidSentryDns(instituteSettings.androidSentryDns)
             .setAccessCodeEnabled(false)
         return settings
     }

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
@@ -14,7 +14,6 @@ import `in`.testpress.testpress.viewmodel.LoginViewModel
 import android.accounts.AccountManager
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/OTPVerificationFragment.kt
@@ -1,9 +1,11 @@
 package `in`.testpress.testpress.ui.fragments
 
+import `in`.testpress.core.TestpressSdk
 import `in`.testpress.enums.Status
 import `in`.testpress.testpress.Injector
 import `in`.testpress.testpress.core.TestpressService
 import `in`.testpress.testpress.databinding.OtpVerificationLayoutBinding
+import `in`.testpress.testpress.models.InstituteSettings
 import `in`.testpress.testpress.repository.InstituteRepository
 import `in`.testpress.testpress.ui.utils.AutoDetectOTP
 import `in`.testpress.testpress.util.UIUtils
@@ -12,6 +14,7 @@ import `in`.testpress.testpress.viewmodel.LoginViewModel
 import android.accounts.AccountManager
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -147,6 +150,7 @@ class OTPVerificationFragment: BaseAuthenticationFragment() {
                     Status.SUCCESS -> {
                         if (resource.data?.token != null) {
                             loginNavigation?.onLoginSuccess(phoneNumber,"", resource.data!!.token!!)
+                            TestpressSdk.initSentry(requireContext(),InstituteSettings.getInstance().androidSentryDns)
                         }
                     }
                     Status.ERROR -> {

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
@@ -197,6 +197,7 @@ class UsernameAuthentication : BaseAuthenticationFragment() {
             .setCoursesFrontend(instituteSettings.showGameFrontend)
             .setCoursesGamificationEnabled(instituteSettings.coursesEnableGamification)
             .setCommentsVotingEnabled(instituteSettings.commentsVotingEnabled)
+            .setAndroidSentryDns(instituteSettings.androidSentryDns)
             .setAccessCodeEnabled(false)
         TestpressSdk.initialize(requireContext(), settings, userId, accessToken, TestpressSdk.Provider.TESTPRESS,
             object : TestpressCallback<TestpressSession?>() {

--- a/app/src/main/java/in/testpress/testpress/viewmodel/AutoLoginViewModel.kt
+++ b/app/src/main/java/in/testpress/testpress/viewmodel/AutoLoginViewModel.kt
@@ -18,6 +18,7 @@ class AutoLoginViewModel: ViewModel() {
                 .setCoursesFrontend(instituteSettings.showGameFrontend)
                 .setCoursesGamificationEnabled(instituteSettings.coursesEnableGamification)
                 .setCommentsVotingEnabled(instituteSettings.commentsVotingEnabled)
+                .setAndroidSentryDns(instituteSettings.androidSentryDns)
                 .setAccessCodeEnabled(false)
 
         testPressSessionRepository.initialize(context,settings,username, password, testPressService)


### PR DESCRIPTION
- In this commit, we set `androidSentryDns` in InstituteSettings of the SDK.
- To ensure Sentry is not initialized during the OTP login process, we initialize Sentry after the OTP login success.
