### PR TITLE
fix: Bookmarks and Discussion button showing in sidebar even if disabled in the portal

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -241,6 +241,7 @@ public class MainActivity extends TestpressFragmentActivity {
         showShareButtonBasedOnInstituteSettings(navigationView.getMenu());
         showRateUsButtonBasedOnInstituteSettings(navigationView.getMenu());
         showDiscussionsButtonBasedOnInstituteSettings(navigationView.getMenu());
+        showBookmarkButtonBasedOnInstituteSettings(navigationView.getMenu());
         updateMenuItemNames(navigationView.getMenu());
         final HandleMainMenu handleMainMenu = new HandleMainMenu(MainActivity.this, serviceProvider);
         navigationView.setNavigationItemSelectedListener(
@@ -262,7 +263,6 @@ public class MainActivity extends TestpressFragmentActivity {
             menu.findItem(R.id.login_activity).setVisible(false);
             menu.findItem(R.id.analytics).setVisible(false);
             menu.findItem(R.id.profile).setVisible(false);
-            menu.findItem(R.id.bookmarks).setVisible(false);
         } else {
             menu.findItem(R.id.logout).setVisible(true);
             if (mInstituteSettings != null) {
@@ -271,7 +271,6 @@ public class MainActivity extends TestpressFragmentActivity {
             menu.findItem(R.id.login_activity).setVisible(true);
             menu.findItem(R.id.analytics).setVisible(true);
             menu.findItem(R.id.profile).setVisible(true);
-            menu.findItem(R.id.bookmarks).setVisible(true);
             menu.findItem(R.id.login).setVisible(false);
             if (mInstituteSettings != null){
                 menu.findItem(R.id.student_report).setVisible(mInstituteSettings.isStudentReportEnabled());
@@ -297,7 +296,17 @@ public class MainActivity extends TestpressFragmentActivity {
                     ? mInstituteSettings.getForumLabel()
                     : getString(R.string.discussions);
             menu.findItem(R.id.discussions).setTitle(discussionsLabel);
-            menu.findItem(R.id.discussions).setVisible(Boolean.TRUE.equals(mInstituteSettings.getShowShareButton()));
+            menu.findItem(R.id.discussions).setVisible(Boolean.TRUE.equals(mInstituteSettings.getForumEnabled()));
+        }
+    }
+
+    private void showBookmarkButtonBasedOnInstituteSettings(Menu menu) {
+        if (mInstituteSettings != null) {
+            String BookmarksLabel = (mInstituteSettings.getBookmarksLabel() != null)
+                    ? mInstituteSettings.getBookmarksLabel()
+                    : getString(R.string.bookmarks);
+            menu.findItem(R.id.bookmarks).setTitle(BookmarksLabel);
+            menu.findItem(R.id.bookmarks).setVisible(Boolean.TRUE.equals(mInstituteSettings.getBookmarksEnabled()));
         }
     }
 

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -5,6 +5,7 @@
         <item
             android:id="@+id/bookmarks"
             android:title="Bookmarks"
+            android:visible="false"
             android:icon="@drawable/ic_bookmark_black_24dp"
             app:showAsAction="never"/>
         <item
@@ -20,6 +21,7 @@
         <item
             android:id="@+id/discussions"
             android:title="Discussions"
+            android:visible="false"
             android:icon="@drawable/chat_icon"
             app:showAsAction="never"/>
         <item


### PR DESCRIPTION
- Handled the bookmark option based on institute settings.
- Applied the same logic for the discussion option to ensure correct visibility according to portal configuration.