### PR TITLE
fix: Institute URL not opening in the app on Android 12 and higher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,14 +52,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="@string/host_url"/>
-                <data android:scheme="http" android:host="@string/host_url" />
-                <data android:scheme="https" android:host="@string/white_labeled_host_url"/>
-                <data android:scheme="http" android:host="@string/white_labeled_host_url"/>
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+                <data android:host="@string/host_url" />
+                <data android:host="@string/white_labeled_host_url" />
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
- Deeplink was not working on Android 12 and higher. In this commit, we added the `autoVerify` attribute to `true` in the AndroidManifest to resolve the issue.