### PR TITLE
fix: Prevent multiple login screens when Enforce Student Data is enabled

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -23,7 +23,6 @@ import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
 
 import android.os.Handler;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -23,6 +23,7 @@ import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
 
 import android.os.Handler;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -500,7 +501,7 @@ public class MainActivity extends TestpressFragmentActivity {
 
                 if (mInstituteSettings == null) {
                     onFinishFetchingInstituteSettings(instituteSettings);
-                } else if (mInstituteSettings.getForceStudentData()) {
+                } else if (isUserAuthenticated && mInstituteSettings.getForceStudentData()) {
                     checkForForceUserData();
                 } else {
                     showMainActivityContents();
@@ -534,7 +535,7 @@ public class MainActivity extends TestpressFragmentActivity {
                 updateTestpressSession();
                 syncVideoWatchedData();
 
-                if (mInstituteSettings.getForceStudentData()) {
+                if (isUserAuthenticated && mInstituteSettings.getForceStudentData()) {
                     checkForForceUserData();
                 }
             }
@@ -627,7 +628,7 @@ public class MainActivity extends TestpressFragmentActivity {
         if (navigationView != null) {
             hideMenuItemsForUnauthenticatedUser(navigationView.getMenu());
         }
-        if (mInstituteSettings != null && mInstituteSettings.getForceStudentData()) {
+        if (isUserAuthenticated && mInstituteSettings != null && mInstituteSettings.getForceStudentData()) {
             checkForForceUserData();
         } else {
             showMainActivityContents();


### PR DESCRIPTION
- Previously, the login screen would open multiple times if the "Enforce Student Data" option was enabled in institute settings. This occurred because the enforcement check was performed before user authentication.
- In this commit, we have updated the logic to check the "Enforce Student Data" setting only after the user has been authenticated. This change resolves the issue of multiple login screens appearing.
