### PR TITLE
enhancement: Update Android Gradle Plugin version to `7.4.2`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         classpath 'com.google.gms:google-services:4.3.14'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
@@ -38,7 +38,6 @@ allprojects {
             content {
                 includeModule("com.google.android", "flexbox")
                 includeModule("com.theartofdev.edmodo", "android-image-cropper")
-                includeModule("com.futuremind.recyclerfastscroll", "fastscroll")
                 includeModule("com.github.skydoves", "powerspinner")
             }
         }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Sep 28 15:30:07 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Updated Android Gradle Plugin version from `7.2.2` to `7.4.2`.
- Updated Gradle version from `7.3.3` to `7.5`.
- Updated corresponding dependencies. See [Docs](https://developer.android.com/build/releases/past-releases/agp-7-4-0-release-notes) for more details.