### PR TITLE
fix: Removed unnecessary permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 <!--    <uses-sdk tools:overrideLibrary="us.zoom.androidlib,us.zoom.videomeetings"/>-->
 
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" tools:node="remove" />
+
     <application
         android:name=".TestpressApplication"
         android:allowBackup="true"


### PR DESCRIPTION
- The following permission `android.permission.FOREGROUND_SERVICE_PHONE_CALL` was requested by the Zoom SDK.
- Since our app does not utilize this permission, it has been explicitly removed to avoid unnecessary permission requests.