### PR TITLE
enhancement: Create draft release in Play Console via GitHub Action

### DIFF
--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -14,8 +14,8 @@ on:
         default: "complete"
         type: choice
         options:
-          - "Complete Release"
-          - "Draft Release"
+          - "Complete-Release"
+          - "Draft-Release"
 
 jobs:
   release_update:

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -8,6 +8,15 @@ on:
         required: true
         default: "all"
 
+      release_option:
+        description: "Select the release option."
+        required: true
+        default: "complete"
+        type: choice
+        options:
+          - "complete"
+          - "draft"
+
 jobs:
   release_update:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -14,8 +14,8 @@ on:
         default: "complete"
         type: choice
         options:
-          - "Complete-Release"
-          - "Draft-Release"
+          - "complete"
+          - "draft"
 
 jobs:
   release_update:

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           export LC_ALL=en_US.UTF-8
           export LANG=en_US.UTF-8
-          bundle exec fastlane release_update_to subdomain:${{ github.event.inputs.subdomain }}
+          bundle exec fastlane release_update_to subdomain:${{ github.event.inputs.subdomain }} release_option:${{ github.event.inputs.release_option }}
 
       - name: Store app artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -9,13 +9,13 @@ on:
         default: "all"
 
       release_option:
-        description: "Select the release option."
+        description: "Choose the type of release. 'Complete' for a full release or 'Draft' for a pre-release version."
         required: true
         default: "complete"
         type: choice
         options:
-          - "complete"
-          - "draft"
+          - "Complete Release"
+          - "Draft Release"
 
 jobs:
   release_update:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -72,10 +72,23 @@ end
 desc "Deploying the app to play store"
 lane :deploy_app do |params|
   download_file(url: params[:play_console_key_file], destination_path: './app/private_key.json')
+
+  # Determine the release status based on release_option
+  release_option = params[:release_option]
+  case release_option
+  when 'Complete Release'
+    releas e_status = 'completed'
+  when 'Draft Release'
+    release_status = 'draft'
+  else
+    release_status = 'completed'
+  end
+
   upload_to_play_store(
     skip_upload_apk: true,
     package_name: params[:package_name],
-    json_key: "%s/app/private_key.json"%File.expand_path("..", Dir.pwd)
+    json_key: "%s/app/private_key.json"%File.expand_path("..", Dir.pwd),
+    release_status: release_status
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -77,23 +77,11 @@ end
 desc "Deploying the app to play store"
 lane :deploy_app do |params|
   download_file(url: params[:play_console_key_file], destination_path: './app/private_key.json')
-
-  # Determine the release status based on release_option
-  release_option = params[:release_option]
-  case release_option
-  when 'Complete-Release'
-    release_status = 'completed'
-  when 'Draft-Release'
-    release_status = 'draft'
-  else
-    release_status = 'completed'
-  end
-
   upload_to_play_store(
     skip_upload_apk: true,
     package_name: params[:package_name],
     json_key: "%s/app/private_key.json"%File.expand_path("..", Dir.pwd),
-    release_status: release_status
+    release_status: params[:release_option]
   )
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -76,9 +76,9 @@ lane :deploy_app do |params|
   # Determine the release status based on release_option
   release_option = params[:release_option]
   case release_option
-  when 'Complete Release'
-    releas e_status = 'completed'
-  when 'Draft Release'
+  when 'Complete-Release'
+    release_status = 'completed'
+  when 'Draft-Release'
     release_status = 'draft'
   else
     release_status = 'completed'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,16 +5,17 @@ lane :build_app_files do |params|
 end
 
 lane :release_update_to do |params|
+  release_option = params[:release_option]
   if params[:subdomain] == "all"
     subdomains = fetch_subdomains
     subdomains.each do |subdomain|
       if ['verandalearning', 'brilliantpalalms', 'brilliantpalaclasses', "race"].include? subdomain
         next
       end
-      release_update(subdomain: subdomain)
+      release_update(subdomain: subdomain, release_option: release_option)
     end
   else
-    release_update(subdomain: params[:subdomain])
+    release_update(subdomain: params[:subdomain], release_option: release_option)
   end
 end
 
@@ -23,7 +24,11 @@ desc "Release updates"
 lane :release_update do |params|
   app_config = update_app_version(subdomain: params[:subdomain])
   generate_customized_app_files(app_config: app_config)
-  deploy_app(play_console_key_file: app_config["play_console_key_file"], package_name: app_config["package_name"])
+  deploy_app(
+    play_console_key_file: app_config["play_console_key_file"],
+    package_name: app_config["package_name"],
+    release_option: params[:release_option]
+  )
 end
 
 desc "Generate Customized app for an institute"


### PR DESCRIPTION
- In this commit, we added the option to upload the app file to the Google Play Console and create a release draft without submitting it for review.
- Previously, running the release update would automatically submit the app for review. In some cases, we need to delay the submission, so we added this option to allow for creating a draft release without immediate submission.
