### PR TITLE
fix: Increase Gradle daemon heap size

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
- GitHub release action failed due to `OutOfMemoryError`. Increasing the Gradle daemon heap size is expected to resolve this issue.
