### PR TITLE
enhancement: Add Catking custom options to Navigation Slider

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -71,6 +71,7 @@ import in.testpress.testpress.models.Update;
 import in.testpress.testpress.ui.fragments.DashboardFragment;
 import in.testpress.testpress.ui.fragments.DiscussionFragmentv2;
 import in.testpress.testpress.ui.utils.HandleMainMenu;
+import in.testpress.testpress.util.AppChecker;
 import in.testpress.testpress.util.CommonUtils;
 import in.testpress.testpress.util.GCMPreference;
 import in.testpress.testpress.util.SafeAsyncTask;
@@ -240,6 +241,7 @@ public class MainActivity extends TestpressFragmentActivity {
         showOfflineExamBasedOnInstituteSettings(navigationView.getMenu());
         showDiscussionsButtonBasedOnInstituteSettings(navigationView.getMenu());
         showBookmarkButtonBasedOnInstituteSettings(navigationView.getMenu());
+        showCustomOptions(navigationView.getMenu());
         updateMenuItemNames(navigationView.getMenu());
         final HandleMainMenu handleMainMenu = new HandleMainMenu(MainActivity.this, serviceProvider);
         navigationView.setNavigationItemSelectedListener(
@@ -311,6 +313,14 @@ public class MainActivity extends TestpressFragmentActivity {
                     : getString(R.string.bookmarks);
             menu.findItem(R.id.bookmarks).setTitle(BookmarksLabel);
             menu.findItem(R.id.bookmarks).setVisible(Boolean.TRUE.equals(mInstituteSettings.getBookmarksEnabled()));
+        }
+    }
+
+    private void showCustomOptions(Menu menu) {
+        if (mInstituteSettings != null && AppChecker.INSTANCE.isCatkingApp(this)) {
+            menu.findItem(R.id.recorded_lessons).setVisible(true);
+            menu.findItem(R.id.mocks).setVisible(true);
+            menu.findItem(R.id.e_books).setVisible(true);
         }
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -120,6 +120,15 @@ public class HandleMainMenu {
             case  R.id.student_report:
                 launchStudentReportActivity();
                 break;
+            case  R.id.recorded_lessons:
+                openCakingExternalURL("Recorded Lessons","/external_site/?endpoint=recorded_lectures");
+                break;
+            case  R.id.mocks:
+                openCakingExternalURL("Mocks","/external_site/?endpoint=mocks");
+                break;
+            case  R.id.e_books:
+                openCakingExternalURL("E-Books","/external_site/?endpoint=e-books");
+                break;
         }
     }
 
@@ -235,5 +244,17 @@ public class HandleMainMenu {
 
     private void launchOfflineExamListActivity() {
         activity.startActivity(new Intent(activity, OfflineExamListActivity.class));
+    }
+
+    private void openCakingExternalURL(String title, String url) {
+        activity.startActivity(
+                WebViewWithSSOActivity.Companion.createIntent(
+                        activity,
+                        title,
+                        BASE_URL + url,
+                        true,
+                        WebViewWithSSOActivity.class
+                )
+        );
     }
 }

--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -253,6 +253,7 @@ public class HandleMainMenu {
                         title,
                         BASE_URL + url,
                         true,
+                        true,
                         WebViewWithSSOActivity.class
                 )
         );

--- a/app/src/main/java/in/testpress/testpress/util/AppChecker.kt
+++ b/app/src/main/java/in/testpress/testpress/util/AppChecker.kt
@@ -2,6 +2,7 @@ package `in`.testpress.testpress.util
 
 import `in`.testpress.testpress.R
 import android.content.Context
+import `in`.testpress.ui.WebViewWithSSOActivity
 
 object AppChecker {
 
@@ -11,5 +12,9 @@ object AppChecker {
 
     fun isLmsDemoApp(context: Context): Boolean {
         return context.getString(R.string.testpress_site_subdomain) == "lmsdemo"
+    }
+
+    fun isCatkingApp(context: Context): Boolean {
+        return context.getString(R.string.testpress_site_subdomain) == "catking"
     }
 }

--- a/app/src/main/res/drawable/outline_smart_display_24.xml
+++ b/app/src/main/res/drawable/outline_smart_display_24.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M9.5,7.5l0,9l7,-4.5z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M20,4H4C2.9,4 2,4.9 2,6v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V6C22,4.9 21.1,4 20,4zM20,18.01H4V5.99h16V18.01z"/>
+</vector>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -42,6 +42,24 @@
             android:icon="@drawable/ic_student_report"
             android:visible="false"
             app:showAsAction="never"/>
+        <item
+            android:id="@+id/recorded_lessons"
+            android:icon="@drawable/outline_smart_display_24"
+            android:title="Recorded Lessons"
+            android:visible="false"
+            app:showAsAction="never" />
+        <item
+            android:id="@+id/mocks"
+            android:icon="@drawable/testpress_exam_icon"
+            android:title="Mocks"
+            android:visible="false"
+            app:showAsAction="never" />
+        <item
+            android:id="@+id/e_books"
+            android:icon="@drawable/testpress_notes_icon"
+            android:title="E-Books"
+            android:visible="false"
+            app:showAsAction="never" />
     </group>
 
     <group


### PR DESCRIPTION
- This commit adds three custom options to the navigation slider: Recorded Lessons, Mocks, and E-Books.
- These options are exclusively visible in the Catking app. When a user selects any of these options, the respective Catking external URL opens in the webview.