### PR TITLE
enhancement: Add Catking custom options to Navigation Slider

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -321,6 +321,9 @@ public class MainActivity extends TestpressFragmentActivity {
             menu.findItem(R.id.recorded_lessons).setVisible(true);
             menu.findItem(R.id.mocks).setVisible(true);
             menu.findItem(R.id.e_books).setVisible(true);
+            menu.findItem(R.id.live_lectures_cat).setVisible(true);
+            menu.findItem(R.id.live_lectures_non_cat).setVisible(true);
+            menu.findItem(R.id.live_lectures_gd_watpi).setVisible(true);
         }
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -129,6 +129,15 @@ public class HandleMainMenu {
             case  R.id.e_books:
                 openCakingExternalURL("E-Books","/external_site/?endpoint=e-books");
                 break;
+            case  R.id.live_lectures_cat:
+                openCakingExternalURL("CAT","/external_site/?endpoint=cat/40-days-challenge");
+                break;
+            case  R.id.live_lectures_non_cat:
+                openCakingExternalURL("NON-CAT","/external_site/?endpoint=noncat/non-cat-40-days-challenge");
+                break;
+            case  R.id.live_lectures_gd_watpi:
+                openCakingExternalURL("GD WATPI","/external_site/?endpoint=gdwatpi/todays-classes");
+                break;
         }
     }
 

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -60,6 +60,31 @@
             android:title="E-Books"
             android:visible="false"
             app:showAsAction="never" />
+        <item
+            android:id="@+id/live_lectures"
+            android:title="Live Lectures"
+            app:showAsAction="never">
+            <menu>
+                <item
+                    android:id="@+id/live_lectures_cat"
+                    android:icon="@drawable/testpress_live_conference_icon"
+                    android:title="CAT"
+                    android:visible="false"
+                    app:showAsAction="never" />
+                <item
+                    android:id="@+id/live_lectures_non_cat"
+                    android:icon="@drawable/testpress_live_conference_icon"
+                    android:title="NON-CAT"
+                    android:visible="false"
+                    app:showAsAction="never" />
+                <item
+                    android:id="@+id/live_lectures_gd_watpi"
+                    android:icon="@drawable/testpress_live_conference_icon"
+                    android:title="GD WATPI"
+                    android:visible="false"
+                    app:showAsAction="never" />
+            </menu>
+        </item>
     </group>
 
     <group


### PR DESCRIPTION
- This commit adds three custom options to the navigation slider: CAT, NON-CAT, and GD WATPI.
- These options are exclusively visible in the Catking app. When a user selects any of these options, the respective Catking external URL opens in the webview.
