### PR TITLE
fix: App version view overlaps with menu options

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -158,7 +158,7 @@ android {
         buildConfigField "String", "BASE_URL", '"https://' + host_url + '"'
         resValue "string", "app_name", json.app_name
         resValue "string", "testpress_site_subdomain", json.testpress_site_subdomain
-        resValue "string", "version", "v " + json.version
+        resValue "string", "version", json.version
         resValue "string", "share_message", json.share_message
         resValue "string", "facebook_app_id", json.facebook_app_id
         resValue "string", "fb_login_protocol_scheme", json.facebook_app_id

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -179,14 +179,10 @@ public class MainActivity extends TestpressFragmentActivity {
 
     private void setupEasterEgg() {
         Menu navigationMenu = navigationView.getMenu();
-        final MenuItem rateUsButton = navigationMenu.findItem(R.id.rate_us);
+        final MenuItem versionInfo = navigationMenu.findItem(R.id.version_info);
         Button button = new Button(this);
         button.setAlpha(0);
-        rateUsButton.setActionView(button);
-        rateUsButton.getActionView().setVisibility(View.GONE);
-
-
-        findViewById(R.id.version_info).setOnLongClickListener(new View.OnLongClickListener() {
+        button.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View view) {
                 Toast.makeText(getApplicationContext(), "App version is " + getString(R.string.version), Toast.LENGTH_SHORT).show();
@@ -201,11 +197,11 @@ public class MainActivity extends TestpressFragmentActivity {
             }
         });
 
-        findViewById(R.id.version_info).setOnClickListener(new View.OnClickListener() {
+        button.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 if (isEasterEggEnabled(getApplicationContext())) {
-                    if (touchCountToEnableScreenShot == 3) {
+                    if (touchCountToEnableScreenShot == 4) {
                         enableScreenShot(getApplicationContext());
                         touchCountToEnableScreenShot = 0;
                     } else {
@@ -216,6 +212,7 @@ public class MainActivity extends TestpressFragmentActivity {
                 }
             }
         });
+        versionInfo.setActionView(button);
     }
 
     private void setUpNavigationDrawer() {
@@ -323,6 +320,7 @@ public class MainActivity extends TestpressFragmentActivity {
             menu.findItem(R.id.posts).setTitle(Strings.toString(mInstituteSettings.getPostsLabel()));
             menu.findItem(R.id.bookmarks).setTitle(Strings.toString(mInstituteSettings.getBookmarksLabel()));
         }
+        menu.findItem(R.id.version_info).setTitle("Version - "+getString(R.string.version));
     }
 
     @Override

--- a/app/src/main/res/drawable/outline_info_24.xml
+++ b/app/src/main/res/drawable/outline_info_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M11,7h2v2h-2zM11,11h2v6h-2zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+</vector>

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -90,23 +90,5 @@
         android:background="@android:color/white"
         app:menu="@menu/main_menu" >
 
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom"
-            android:orientation="vertical"
-            android:padding="16dp">
-
-            <TextView
-                android:id="@+id/version_info"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:textSize="12sp"
-                android:textColor="@color/testpress_text_gray"
-                android:text="@string/version" />
-        </LinearLayout>
-
     </com.google.android.material.navigation.NavigationView>
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -86,5 +86,10 @@
             android:icon="@drawable/ic_share_white_24dp"
             android:title="Share"
             app:showAsAction="always"/>
+        <item
+            android:id="@+id/version_info"
+            android:icon="@drawable/outline_info_24"
+            android:title="Version:1.0.0"
+            app:showAsAction="always"/>
     </group>
 </menu>


### PR DESCRIPTION
- Adding more options to the navigation caused the version view to overlap with menu options. In this commit, we moved the version to be one of the menu options.
- The existing easter egg functionality remains unchanged and continues to work with the new version option placement.