### PR TITLE
fix: Request Storage permission after user login

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 ext {
-    testpressSDK = '1.4.164'
+    testpressSDK = '1.4.165'
 }
 
 def jsonFile = file('src/main/assets/config.json')

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -1,4 +1,5 @@
 package in.testpress.testpress.ui;
+import in.testpress.RequestCode;
 import in.testpress.course.ui.CourseListFragment;
 
 import android.Manifest;
@@ -371,7 +372,7 @@ public class MainActivity extends TestpressFragmentActivity {
                 if (viewPager.getVisibility() != View.VISIBLE) {
                     initScreen();
                 }
-                askNotificationPermission();
+                askNotificationAndStoragePermission();
             }
         }.execute();
     }
@@ -748,9 +749,23 @@ public class MainActivity extends TestpressFragmentActivity {
         }
     }
 
-    private void askNotificationPermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS},1000);
+    private void askNotificationAndStoragePermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            requestPermissions(new String[]{
+                    Manifest.permission.POST_NOTIFICATIONS,
+                    Manifest.permission.READ_MEDIA_IMAGES,
+                    Manifest.permission.READ_MEDIA_VIDEO,
+                    Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED
+            }, RequestCode.PERMISSION);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            requestPermissions(new String[]{
+                    Manifest.permission.POST_NOTIFICATIONS,
+                    Manifest.permission.READ_MEDIA_IMAGES,
+                    Manifest.permission.READ_MEDIA_VIDEO
+            }, RequestCode.PERMISSION);
+        } else {
+            requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, RequestCode.PERMISSION);
+
         }
     }
 


### PR DESCRIPTION
- Previously, after user authentication, we only requested notification permission. Now, we also request storage permission immediately after login because it is needed in more than five places throughout the app.
- Requesting storage permission at this point is crucial as it ensures seamless functionality across various features that rely on storage access.
- Upgraded Testpress SDK version from `1.4.164` to `1.4.165`.