### PR TITLE
fix: Not able to navigate to OTPVerificationFragment after entering the mobile number

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/utils/AutoDetectOTP.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/AutoDetectOTP.kt
@@ -2,8 +2,10 @@ package `in`.testpress.testpress.ui.utils
 
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Context.RECEIVER_EXPORTED
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.gms.auth.api.phone.SmsRetriever
 import com.google.android.gms.common.api.CommonStatusCodes
@@ -50,7 +52,11 @@ class AutoDetectOTP(val context: Context) {
                 }
             }
         }
-        appCompatActivity.application.registerReceiver(broadcastReceiver, intentFilter)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU){
+            appCompatActivity.application.registerReceiver(broadcastReceiver, intentFilter, RECEIVER_EXPORTED)
+        } else {
+            appCompatActivity.application.registerReceiver(broadcastReceiver, intentFilter)
+        }
     }
 
     fun stopSmsReceiver() {


### PR DESCRIPTION
- Previously, the broadcast receiver was registered without considering the Android version. Now, we conditionally use `RECEIVER_EXPORTED` for Android 13 and above to comply with new security requirements. This change prevents `SecurityException` and ensures proper receiver registration based on the Android version. For more details, refer to [Android Developer Documentation](https://developer.android.com/develop/background-work/background-tasks/broadcasts#context-registered-receivers).