### PR TITLE
fix: Unable to release update from Android App config form

### DIFF
--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -9,7 +9,7 @@ on:
         default: "all"
 
       release_option:
-        description: "Choose the type of release. 'Complete' for a full release or 'Draft' for a pre-release version."
+        description: "Choose the type of release. 'Completed' for a full release or 'Draft' for a pre-release version."
         default: "completed"
         type: choice
         options:

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -10,11 +10,10 @@ on:
 
       release_option:
         description: "Choose the type of release. 'Complete' for a full release or 'Draft' for a pre-release version."
-        required: true
-        default: "complete"
+        default: "completed"
         type: choice
         options:
-          - "complete"
+          - "completed"
           - "draft"
 
 jobs:


### PR DESCRIPTION
- In commit 7b720b2, we added an option to upload the app file to the Google Play Console and create a release draft without submitting it for review.
- The `release_option` field was set as required, but its value was not being received from the Android App config form, causing the action to fail.
- In this commit, we set `release_option` as a non-required field with the default value set to `completed`.