### PR TITLE
fix: Release Actions are failing

### DIFF
--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -10,11 +10,11 @@ on:
 
       release_option:
         description: "Choose the type of release. 'Completed' for a full release or 'Draft' for a pre-release version."
+        default: "completed"
         type: choice
         options:
           - "completed"
           - "draft"
-        default: "completed"
 
 jobs:
   release_update:

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -80,7 +80,7 @@ jobs:
           bundle exec fastlane release_update_to subdomain:${{ github.event.inputs.subdomain }} release_option:${{ github.event.inputs.release_option }}
 
       - name: Store app artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: |

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -10,11 +10,11 @@ on:
 
       release_option:
         description: "Choose the type of release. 'Completed' for a full release or 'Draft' for a pre-release version."
-        default: "completed"
         type: choice
         options:
           - "completed"
           - "draft"
+        default: "completed"
 
 jobs:
   release_update:


### PR DESCRIPTION
- Release actions were failing due to the deprecated `actions/upload-artifact@v2`.
- In this commit, we updated the action to `actions/upload-artifact@v4`, which resolves the issue.