### PR TITLE
fix: Build Actions are failing

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -72,7 +72,7 @@ jobs:
           bundle exec fastlane build_app_files subdomain:${{ github.event.inputs.subdomain }}
 
       - name: Store app artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: |


### PR DESCRIPTION
- Build actions were failing due to the deprecated `actions/upload-artifact@v2`.
- In this commit, we updated the action to `actions/upload-artifact@v4`, which resolves the issue.