### PR TITLE
fix: App crash on Android 13+ during SMS verification

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.CountDownTimer;
 import android.provider.Settings;
@@ -113,7 +114,12 @@ public class CodeVerificationActivity extends AppCompatActivity {
             smsReceivingEvent = new SmsReceivingEvent(timer);
             IntentFilter filter = new IntentFilter();
             filter.addAction(SmsRetriever.SMS_RETRIEVED_ACTION);
-            registerReceiver(smsReceivingEvent, filter); //Register SMS broadcast receiver
+            //Register SMS broadcast receiver
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU){
+                registerReceiver(smsReceivingEvent, filter, RECEIVER_EXPORTED);
+            } else {
+                registerReceiver(smsReceivingEvent, filter);
+            }
             timer.start(); // Start timer
         }
         verificationCodeText.addTextChangedListener(watcher);


### PR DESCRIPTION
- App crashes on Android 13 (API level 33) and higher during SMS verification. The issue was caused by the `registerReceiver` method, which now requires the `RECEIVER_EXPORTED` flag on Android 13 and above. 
- Updated the `registerReceiver` call to use the RECEIVER_EXPORTED flag for devices running Android 13 (Tiramisu) or higher.
- For more details, refer to [Android Developer Documentation](https://developer.android.com/develop/background-work/background-tasks/broadcasts#context-registered-receivers).


