### PR TITLE
fix: Deep Link Handling for Password Reset

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
@@ -82,7 +82,7 @@ public class DeeplinkHandler {
                     }
                     break;
                 case "password":
-                    gotoActivity(ResetPasswordActivity.class, false);
+                    openBrowserForResetPassword(uri);
                     break;
                 case "analytics":
                     authenticateUserAndOpen(uri);
@@ -118,6 +118,11 @@ public class DeeplinkHandler {
         } else {
             openBrowserOrGotoHome(uri, fromSplashScreen);
         }
+    }
+
+    private void openBrowserForResetPassword(Uri uri) {
+        CommonUtils.openUrlInBrowser(activity, uri);
+        activity.finish();
     }
 
     private void openBrowserOrGotoHome(Uri uri, boolean fromSplashScreen) {


### PR DESCRIPTION
- Users can only reset their passwords through the browser. However, when users click the password reset URL on an Android mobile device, the app opens instead, preventing them from resetting their password.
- In this commit, we ensure that when users click the password reset URL, they are redirected to the browser to facilitate the password reset process.