### PR TITLE
feat: Integrate Salesforce Marketing Cloud SDK for Enhanced Push Notifications

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,6 +101,7 @@ dependencies {
 
     implementation 'com.github.mhiew:android-pdf-viewer:3.2.0-beta.1'
     implementation 'com.github.alexto9090:PRDownloader:1.0'
+    implementation 'com.salesforce.marketingcloud:marketingcloudsdk:8.0.7'
 }
 
 def key_alias = "sample"

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -76,6 +76,7 @@ import in.testpress.testpress.util.AppChecker;
 import in.testpress.testpress.util.CommonUtils;
 import in.testpress.testpress.util.GCMPreference;
 import in.testpress.testpress.util.SafeAsyncTask;
+import in.testpress.testpress.util.SalesforceSdkInitializer;
 import in.testpress.testpress.util.Strings;
 import in.testpress.testpress.util.UIUtils;
 import in.testpress.testpress.util.UpdateAppDialogManager;
@@ -375,6 +376,7 @@ public class MainActivity extends TestpressFragmentActivity {
                 if (viewPager.getVisibility() != View.VISIBLE) {
                     initScreen();
                 }
+                initSalesForceSDK();
                 askNotificationAndStoragePermission();
             }
         }.execute();
@@ -786,4 +788,8 @@ public class MainActivity extends TestpressFragmentActivity {
         editor.apply();
     }
 
+    private void initSalesForceSDK() {
+        SalesforceSdkInitializer salesforceSdkInitializer = new SalesforceSdkInitializer(this);
+        salesforceSdkInitializer.initialize(mInstituteSettings);
+    }
 }

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -10,10 +10,12 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.view.GravityCompat;
@@ -789,7 +791,35 @@ public class MainActivity extends TestpressFragmentActivity {
     }
 
     private void initSalesForceSDK() {
-        SalesforceSdkInitializer salesforceSdkInitializer = new SalesforceSdkInitializer(this);
-        salesforceSdkInitializer.initialize(mInstituteSettings);
+        if (Boolean.TRUE.equals(mInstituteSettings.getSalesforceSdkEnabled())) {
+            SalesforceSdkInitializer salesforceSdkInitializer = new SalesforceSdkInitializer(this);
+            salesforceSdkInitializer.initialize(mInstituteSettings);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && requestCode == RequestCode.PERMISSION) {
+            handleNotificationPermissionResult(permissions, grantResults);
+        }
+    }
+
+    private void handleNotificationPermissionResult(@NonNull String[] permissions, @NonNull int[] grantResults) {
+        for (int i = 0; i < permissions.length; i++) {
+            if (Manifest.permission.POST_NOTIFICATIONS.equals(permissions[i])) {
+                if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+                    onNotificationPermissionGranted();
+                }
+                return;
+            }
+        }
+    }
+
+    private void onNotificationPermissionGranted() {
+        if (Boolean.TRUE.equals(mInstituteSettings.getSalesforceSdkEnabled())) {
+            SalesforceSdkInitializer.notificationPermissionGranted();
+        }
     }
 }

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -802,19 +802,19 @@ public class MainActivity extends TestpressFragmentActivity {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && requestCode == RequestCode.PERMISSION) {
-            handleNotificationPermissionResult(permissions, grantResults);
+            if (isNotificationPermissionGranted(permissions, grantResults)) {
+                onNotificationPermissionGranted();
+            }
         }
     }
 
-    private void handleNotificationPermissionResult(@NonNull String[] permissions, @NonNull int[] grantResults) {
+    private boolean isNotificationPermissionGranted(@NonNull String[] permissions, @NonNull int[] grantResults) {
         for (int i = 0; i < permissions.length; i++) {
-            if (Manifest.permission.POST_NOTIFICATIONS.equals(permissions[i])) {
-                if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
-                    onNotificationPermissionGranted();
-                }
-                return;
+            if (Manifest.permission.POST_NOTIFICATIONS.equals(permissions[i]) && grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+                return true;
             }
         }
+        return false;
     }
 
     private void onNotificationPermissionGranted() {

--- a/app/src/main/java/in/testpress/testpress/util/SalesforceSdkInitializer.java
+++ b/app/src/main/java/in/testpress/testpress/util/SalesforceSdkInitializer.java
@@ -1,0 +1,65 @@
+package in.testpress.testpress.util;
+
+import android.content.Context;
+import android.util.Log;
+
+
+import com.salesforce.marketingcloud.MCLogListener;
+import com.salesforce.marketingcloud.MarketingCloudConfig;
+import com.salesforce.marketingcloud.MarketingCloudSdk;
+import com.salesforce.marketingcloud.notifications.NotificationCustomizationOptions;
+import com.salesforce.marketingcloud.sfmcsdk.BuildConfig;
+import com.salesforce.marketingcloud.sfmcsdk.SFMCSdk;
+import com.salesforce.marketingcloud.sfmcsdk.SFMCSdkModuleConfig;
+import com.salesforce.marketingcloud.sfmcsdk.components.logging.LogLevel;
+import com.salesforce.marketingcloud.sfmcsdk.components.logging.LogListener;
+
+import in.testpress.testpress.R;
+import in.testpress.testpress.models.InstituteSettings;
+
+public class SalesforceSdkInitializer {
+
+    private final Context context;
+    private InstituteSettings instituteSettings;
+
+    public SalesforceSdkInitializer(Context context) {
+        this.context = context;
+    }
+
+    public void initialize(InstituteSettings settings) {
+        this.instituteSettings = settings;
+        Log.d("TAG", "initialize1: "+instituteSettings.getBaseUrl());
+        configureLogging();
+        MarketingCloudConfig marketingCloudConfig = buildMarketingCloudConfig();
+        SFMCSdkModuleConfig sdkModuleConfig = buildSFMCSdkModuleConfig(marketingCloudConfig);
+        SFMCSdk.Companion.configure(context, sdkModuleConfig);
+        Log.d("TAG", "initialize2: "+instituteSettings.getBaseUrl());
+    }
+
+    private void configureLogging() {
+        if (BuildConfig.DEBUG) {
+            MarketingCloudSdk.setLogLevel(MCLogListener.VERBOSE);
+            MarketingCloudSdk.setLogListener(new MCLogListener.AndroidLogListener());
+        }
+    }
+
+    private MarketingCloudConfig buildMarketingCloudConfig() {
+        return MarketingCloudConfig.Companion.builder()
+                .setApplicationId("b0562d0e-76e4-44a8-9725-ffe64392534b")
+                .setAccessToken("orq2HdhvFgq4qJDdn7OH4J3U")
+                .setSenderId("423776142021")
+                .setMarketingCloudServerUrl("https://mczgg3rvb2rq3vslc0q19lzt-pp0.device.marketingcloudapis.com/")
+                .setNotificationCustomizationOptions(
+                        NotificationCustomizationOptions.create(R.drawable.ic_stat_notification)
+                )
+                .build(context);
+    }
+
+    private SFMCSdkModuleConfig buildSFMCSdkModuleConfig(MarketingCloudConfig marketingCloudConfig) {
+        return SFMCSdkModuleConfig.Companion.build(builder -> {
+            builder.setPushModuleConfig(marketingCloudConfig);
+            return null;
+        });
+    }
+}
+

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ allprojects {
         jcenter()
         maven {url "https://phonepe.mycloudrepo.io/public/repositories/phonepe-intentsdk-android"}
         maven { url "https://github.com/testpress/Android-Image-Cropper/raw/main" }
+        maven { url "https://salesforce-marketingcloud.github.io/MarketingCloudSDK-Android/repository" }
 
     }
 }


### PR DESCRIPTION
- This PR integrates the Salesforce Marketing Cloud SDK for push notifications.
- Added `marketingcloudsdk` dependency in `build.gradle`.
- Implemented `SalesforceSdkInitializer` to configure and initialize the SDK in `MainActivity`.
- Added logic to handle notification permission and enable push notifications upon grant.
