### PR TITLE
fix: Update Firebase dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,8 +51,8 @@ dependencies {
     implementation 'com.github.testpress:store:' + testpressSDK
 
     // Gcm
-    implementation 'com.google.firebase:firebase-core:19.0.0'
-    implementation 'com.google.firebase:firebase-messaging:19.0.1'
+    implementation 'com.google.firebase:firebase-core:21.1.1'
+    implementation 'com.google.firebase:firebase-messaging:24.1.0'
     implementation 'org.greenrobot:eventbus:3.1.1'
 
     // Google Sign In

--- a/app/src/main/java/in/testpress/testpress/util/CommonUtils.java
+++ b/app/src/main/java/in/testpress/testpress/util/CommonUtils.java
@@ -18,8 +18,7 @@ import android.util.Log;
 
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
-import com.google.firebase.iid.FirebaseInstanceId;
-import com.google.firebase.iid.InstanceIdResult;
+import com.google.firebase.messaging.FirebaseMessaging;
 
 import java.util.List;
 
@@ -118,19 +117,18 @@ public class CommonUtils {
     public static void registerDevice(final Activity activity,
                                       final TestpressService testpressService) {
 
-        FirebaseInstanceId.getInstance().getInstanceId()
-                .addOnCompleteListener(new OnCompleteListener<InstanceIdResult>() {
+        FirebaseMessaging.getInstance().getToken()
+                .addOnCompleteListener(new OnCompleteListener<String>() {
                     @Override
-                    public void onComplete(@NonNull Task<InstanceIdResult> task) {
+                    public void onComplete(@NonNull Task<String> task) {
                         if (!task.isSuccessful()) {
                             Log.d("registerDevice", "getInstanceId failed", task.getException());
                             return;
                         }
-
-                        // Get new Instance ID token
-                        //noinspection ConstantConditions
-                        String token = task.getResult().getToken();
+                        // Get new FCM registration token
+                        String token = task.getResult();
                         registerDevice(activity, token, testpressService);
+
                     }
                 });
     }

--- a/app/src/main/java/in/testpress/testpress/util/CommonUtils.java
+++ b/app/src/main/java/in/testpress/testpress/util/CommonUtils.java
@@ -128,7 +128,6 @@ public class CommonUtils {
                         // Get new FCM registration token
                         String token = task.getResult();
                         registerDevice(activity, token, testpressService);
-
                     }
                 });
     }


### PR DESCRIPTION
- Updated `firebase-core` to `21.1.1` and `firebase-messaging` to `24.1.0`.
- Replaced deprecated `FirebaseInstanceId` with` FirebaseMessaging.getToken()`.
- Ensures compatibility with the latest Firebase SDK and removes deprecated API usage.
