### PR TITLE
fix: Unable to return to dashboard after submitting Enforce Data form

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -241,6 +241,10 @@
             android:theme="@style/AppTheme"
             android:configChanges="orientation|keyboardHidden|screenSize"/>
 
+        <activity android:name=".ui.EnforceDataActivity"
+            android:theme="@style/AppTheme"
+            android:configChanges="orientation|keyboardHidden|screenSize"/>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/in/testpress/testpress/TestpressModule.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressModule.java
@@ -31,6 +31,7 @@ import in.testpress.testpress.ui.DocumentsListFragment;
 import in.testpress.testpress.ui.DoubtsActivity;
 import in.testpress.testpress.ui.DrupalRssListActivity;
 import in.testpress.testpress.ui.DrupalRssListFragment;
+import in.testpress.testpress.ui.EnforceDataActivity;
 import in.testpress.testpress.ui.ForumActivity;
 import in.testpress.testpress.ui.ForumListActivity;
 import in.testpress.testpress.ui.ForumListFragment;
@@ -98,7 +99,8 @@ import static in.testpress.testpress.BuildConfig.BASE_URL;
                 PhoneAuthenticationFragment.class,
                 OTPVerificationFragment.class,
                 TermsAndConditionActivity.class,
-                AccountDeleteActivity.class
+                AccountDeleteActivity.class,
+                EnforceDataActivity.class
         }
 )
 public class TestpressModule {

--- a/app/src/main/java/in/testpress/testpress/ui/EnforceDataActivity.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/EnforceDataActivity.kt
@@ -1,0 +1,97 @@
+package `in`.testpress.testpress.ui
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.util.Log
+import android.view.Menu
+import android.view.MenuItem
+import android.webkit.CookieManager
+import android.webkit.JavascriptInterface
+import androidx.appcompat.app.AlertDialog
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import `in`.testpress.testpress.Injector
+import `in`.testpress.testpress.R
+import `in`.testpress.testpress.TestpressServiceProvider
+import `in`.testpress.testpress.authenticator.LogoutService
+import `in`.testpress.testpress.core.TestpressService
+import `in`.testpress.ui.AbstractWebViewActivity
+import `in`.testpress.util.BaseJavaScriptInterface
+import javax.inject.Inject
+
+class EnforceDataActivity : AbstractWebViewActivity() {
+
+    @Inject
+    lateinit var serviceProvider: TestpressServiceProvider
+    @Inject
+    lateinit var testpressService: TestpressService
+    @Inject
+    lateinit var logoutService: LogoutService
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Injector.inject(this)
+        if(!isPermissionGranted(Manifest.permission.CAMERA)){
+            askCameraPermission()
+        }
+    }
+
+    private fun isPermissionGranted(permissionName: String): Boolean {
+        return ContextCompat.checkSelfPermission(
+            this,
+            permissionName
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun askCameraPermission() {
+        ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.CAMERA), 1)
+    }
+
+    override fun onWebViewInitializationSuccess() {
+        webViewFragment.addJavascriptInterface(JavaScriptInterface(), "AndroidInterface")
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.logout, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        val id = item.itemId
+        if (id == R.id.logout) {
+            logout()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    fun logout() {
+        AlertDialog.Builder(this, R.style.AppCompatAlertDialogStyle)
+            .setTitle(R.string.logout)
+            .setMessage(R.string.logout_confirm_message)
+            .setPositiveButton(
+                R.string.ok
+            ) { dialogInterface, i ->
+                dialogInterface.dismiss()
+                serviceProvider.logout(
+                    this@EnforceDataActivity,
+                    testpressService,
+                    serviceProvider,
+                    logoutService
+                )
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    inner class JavaScriptInterface : BaseJavaScriptInterface(this) {
+
+        @JavascriptInterface
+        fun onSubmit() {
+            finish()
+        }
+
+    }
+
+}

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -138,8 +138,6 @@ public class MainActivity extends TestpressFragmentActivity {
         setContentView(R.layout.main_activity);
         ButterKnife.inject(this);
 
-        Log.d("TAG", "onCreate: ");
-
         if (savedInstanceState != null) {
             mSelectedItem = savedInstanceState.getInt(SELECTED_ITEM);
         }
@@ -520,7 +518,7 @@ public class MainActivity extends TestpressFragmentActivity {
                 if (mInstituteSettings == null) {
                     onFinishFetchingInstituteSettings(instituteSettings);
                 } else if (isUserAuthenticated && mInstituteSettings.getForceStudentData()) {
-                    //checkForForceUserData();
+                    checkForForceUserData();
                 } else {
                     showMainActivityContents();
                 }
@@ -554,7 +552,7 @@ public class MainActivity extends TestpressFragmentActivity {
                 syncVideoWatchedData();
 
                 if (isUserAuthenticated && mInstituteSettings.getForceStudentData()) {
-                    //checkForForceUserData();
+                    checkForForceUserData();
                 }
             }
         }
@@ -654,7 +652,6 @@ public class MainActivity extends TestpressFragmentActivity {
     }
 
     public void openEnforceDataActivity(){
-        Log.d("TAG", "openEnforceDataActivity: "+ BASE_URL + "/settings/force/mobile/");
         this.startActivity(
                 EnforceDataActivity.Companion.createIntent(
                         this,


### PR DESCRIPTION
- Previously, the `WebViewActivity` lacked a JavaScript interface callback, causing the WebView activity to remain open after data submission.
- Added `EnforceDataActivity` to handle data submission and close the activity upon successful submission.
- Removed the old implementation for enforcing data.