### PR TITLE
fix: Removed unnecessary permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
 <!--    <uses-sdk tools:overrideLibrary="us.zoom.androidlib,us.zoom.videomeetings"/>-->
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" tools:node="remove" />
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"  tools:node="remove"/>
 
     <application
         android:name=".TestpressApplication"


### PR DESCRIPTION
- The permission com.google.android.gms.permission.AD_ID was added by the Google Play Services library.
- Since our app does not use Google Ads, this permission has been explicitly removed to prevent unnecessary requests.