### PR TITLE
fix: Remove unnecessary permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,8 +21,13 @@
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 <!--    <uses-sdk tools:overrideLibrary="us.zoom.androidlib,us.zoom.videomeetings"/>-->
 
+    <!-- Permissions added by Zoom SDK that are not required, so they are being removed -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" tools:node="remove" />
-    <uses-permission android:name="com.google.android.gms.permission.AD_ID"  tools:node="remove"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" tools:node="remove" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" tools:node="remove" />
+
+    <!-- Permissions added by Google Play Services SDK that are not needed, so they are being removed -->
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID" tools:node="remove"/>
 
     <application
         android:name=".TestpressApplication"


### PR DESCRIPTION
- The Zoom SDK requested the following permissions `ACCESS_FINE_LOCATION` and `ACCESS_COARSE_LOCATION`.
- Since our app does not utilize this permission, it has been explicitly removed to avoid unnecessary permission requests.
