### PR TITLE
fix: Resolve GitHub Actions build failures

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -22,11 +22,11 @@ jobs:
         run: |
           curl -f https://${{ github.event.inputs.subdomain }}.testpress.in/api/v2.5/admin/android/app-config/ -H "API-access-key: $API_ACCESS_KEY"
 
-      - name: Setup JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: "corretto"
-          java-version: 11
+          distribution: "temurin"
+          java-version: 17
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           curl -f https://${{ github.event.inputs.subdomain }}.testpress.in/api/v2.5/admin/android/app-config/ -H "API-access-key: $API_ACCESS_KEY"
 
-      - name: Set up JDK 17
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"

--- a/.github/workflows/generate_debug_apk.yml
+++ b/.github/workflows/generate_debug_apk.yml
@@ -16,11 +16,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch_name }}
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: "corretto"
-          java-version: 11
+          distribution: "temurin"
+          java-version: 17
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -30,11 +30,11 @@ jobs:
         run: |
           curl -f https://${{ github.event.inputs.subdomain }}.testpress.in/api/v2.5/admin/android/app-config/ -H "API-access-key: $API_ACCESS_KEY"
 
-      - name: Setup JDK 11
+      - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
-          distribution: "corretto"
-          java-version: 11
+          distribution: "temurin"
+          java-version: 17
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2


### PR DESCRIPTION
- Updated GitHub Actions workflows to use JDK 17 with the Temurin distribution. The change resolves build failures caused by incompatibility between the Android SDK's command-line tools (requiring JDK 17) and the previously configured JDK 11.
