### PR TITLE
fix: Prevent redundant API calls in DashboardFragment

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/fragments/DashboardFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/DashboardFragment.java
@@ -13,7 +13,6 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/DashboardFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/DashboardFragment.java
@@ -13,6 +13,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -197,12 +198,6 @@ public class DashboardFragment extends Fragment implements
         setDashboardData(getContext(), json);
         adapter.setResponse(data);
         adapter.notifyDataSetChanged();
-    }
-
-    @Override
-    public void onResume() {
-        super.onResume();
-        refresh();
     }
 
     private void setEmptyText() {


### PR DESCRIPTION
- This PR resolves an issue where the dashboard API was being called multiple times during the initialization of DashboardFragment.
- The API was being called three times: once in onCreate() and twice in onResume().
- The redundant calls in onResume() were unnecessary and caused inefficiencies.
- Removed the onResume() override where refresh() was being called.
- This ensures the API is only called during initialization or as explicitly required, preventing duplicate calls.