### PR TITLE
fix: Use WHITE_LABELED_HOST_URL for webviews to support custom domains 

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -89,6 +89,7 @@ import io.sentry.android.core.SentryAndroid;
 import static in.testpress.testpress.BuildConfig.ALLOW_ANONYMOUS_USER;
 import static in.testpress.testpress.BuildConfig.APPLICATION_ID;
 import static in.testpress.testpress.BuildConfig.BASE_URL;
+import static in.testpress.testpress.BuildConfig.WHITE_LABELED_HOST_URL;
 import static in.testpress.testpress.ui.TermsAndConditionActivityKt.TERMS_AND_CONDITIONS;
 import static in.testpress.testpress.ui.utils.EasterEggUtils.enableOrDisableEasterEgg;
 import static in.testpress.testpress.ui.utils.EasterEggUtils.enableScreenShot;
@@ -658,7 +659,7 @@ public class MainActivity extends TestpressFragmentActivity {
                 EnforceDataActivity.Companion.createIntent(
                         this,
                         "Mandatory Update",
-                        BASE_URL + "/settings/force/mobile/",
+                        WHITE_LABELED_HOST_URL + "/settings/force/mobile/",
                         true,
                         false,
                         EnforceDataActivity.class

--- a/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
@@ -76,6 +76,7 @@ import in.testpress.testpress.util.Strings;
 
 import static android.view.inputmethod.EditorInfo.IME_ACTION_DONE;
 import static in.testpress.testpress.BuildConfig.BASE_URL;
+import static in.testpress.testpress.BuildConfig.WHITE_LABELED_HOST_URL;
 
 public class ProfileDetailsActivity extends BaseAuthenticatedActivity
         implements LoaderManager.LoaderCallbacks<ProfileDetails> {
@@ -181,7 +182,7 @@ public class ProfileDetailsActivity extends BaseAuthenticatedActivity
                         AccountDeleteActivity.Companion.createIntent(
                                 ProfileDetailsActivity.this,
                                 "Delete Account",
-                                BASE_URL + "/settings/account/delete/",
+                                WHITE_LABELED_HOST_URL + "/settings/account/delete/",
                                 true,
                                 false,
                                 AccountDeleteActivity.class

--- a/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/DeeplinkHandler.java
@@ -28,6 +28,7 @@ import in.testpress.util.Assert;
 
 import static in.testpress.exam.api.TestpressExamApiClient.SUBJECT_ANALYTICS_PATH;
 import static in.testpress.testpress.BuildConfig.BASE_URL;
+import static in.testpress.testpress.BuildConfig.WHITE_LABELED_HOST_URL;
 import static in.testpress.testpress.core.Constants.Http.CHAPTERS_PATH;
 import static in.testpress.testpress.ui.PostActivity.DETAIL_URL;
 
@@ -221,7 +222,7 @@ public class DeeplinkHandler {
         activity.startActivityForResult(WebViewWithSSOActivity.Companion.createIntent(
                 activity,
                 "Discussion",
-                BASE_URL + "/discussions/new/" + discussionSlug,
+                WHITE_LABELED_HOST_URL + "/discussions/new/" + discussionSlug,
                 true,
                 false,
                 WebViewWithSSOActivity.class

--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -37,6 +37,7 @@ import in.testpress.ui.WebViewWithSSOActivity;
 import static in.testpress.exam.api.TestpressExamApiClient.SUBJECT_ANALYTICS_PATH;
 import static in.testpress.testpress.BuildConfig.APPLICATION_ID;
 import static in.testpress.testpress.BuildConfig.BASE_URL;
+import static in.testpress.testpress.BuildConfig.WHITE_LABELED_HOST_URL;
 import static in.testpress.testpress.core.Constants.Http.URL_PRIVACY_POLICY_FLAG;
 import static in.testpress.testpress.core.Constants.Http.URL_STUDENT_REPORT_FLAG;
 
@@ -217,7 +218,7 @@ public class HandleMainMenu {
                 WebViewWithSSOActivity.Companion.createIntent(
                         activity,
                         activity.getString(R.string.student_report),
-                        BASE_URL + URL_STUDENT_REPORT_FLAG,
+                        WHITE_LABELED_HOST_URL + URL_STUDENT_REPORT_FLAG,
                         true,
                         false,
                         WebViewWithSSOActivity.class
@@ -230,7 +231,7 @@ public class HandleMainMenu {
                 WebViewWithSSOActivity.Companion.createIntent(
                         activity,
                         activity.getString(R.string.privacy_policy),
-                        BASE_URL + URL_PRIVACY_POLICY_FLAG,
+                        WHITE_LABELED_HOST_URL + URL_PRIVACY_POLICY_FLAG,
                         false,
                         false,
                         WebViewWithSSOActivity.class
@@ -243,7 +244,7 @@ public class HandleMainMenu {
                 WebViewWithSSOActivity.Companion.createIntent(
                         activity,
                         title,
-                        BASE_URL + "/discussions/new",
+                        WHITE_LABELED_HOST_URL + "/discussions/new",
                         true,
                         false,
                         WebViewWithSSOActivity.class


### PR DESCRIPTION
#### Issue:
- Previously, webviews for privacy policy, enforce data form, discussions, etc., were always opened using our own domain (BASE_URL). However, some institutions use custom domains, and these webviews were not working correctly for them.

#### Changes:
- Updated the code to use WHITE_LABELED_HOST_URL instead of BASE_URL for all relevant webviews.
- If a custom domain is not available, the default domain (our domain) will be used as specified in the WHITE_LABELED_HOST_URL field.