### PR TITLE
fix: Add white-labeled host URL in InstituteSettings for consistent configuration

### DIFF
--- a/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressServiceProvider.java
@@ -106,6 +106,7 @@ public class TestpressServiceProvider {
 
             if (instituteSettingsList.isEmpty()) {
                 settings = new in.testpress.models.InstituteSettings(BASE_URL);
+                settings.setWhiteLabeledHostUrl(BuildConfig.WHITE_LABELED_HOST_URL);
                 settings.setScreenshotDisabled(true);
                 settings.setVideoDownloadEnabled(true);
                 settings.setShowPDFVertically(SHOW_PDF_VERTICALLY);

--- a/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
@@ -40,6 +40,7 @@ import in.testpress.core.TestpressCallback;
 import in.testpress.core.TestpressException;
 import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
+import in.testpress.testpress.BuildConfig;
 import in.testpress.testpress.Injector;
 import in.testpress.testpress.R;
 import in.testpress.testpress.TestpressApplication;
@@ -246,6 +247,7 @@ public class CodeVerificationActivity extends AppCompatActivity {
     private void autoLogin() {
         in.testpress.models.InstituteSettings settings =
                 new in.testpress.models.InstituteSettings(instituteSettings.getBaseUrl())
+                        .setWhiteLabeledHostUrl(BuildConfig.WHITE_LABELED_HOST_URL)
                         .setBookmarksEnabled(instituteSettings.getBookmarksEnabled())
                         .setCoursesFrontend(instituteSettings.getShowGameFrontend())
                         .setCoursesGamificationEnabled(instituteSettings.getCoursesEnableGamification())

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -61,6 +61,7 @@ import in.testpress.core.TestpressSdk;
 import in.testpress.core.TestpressSession;
 import in.testpress.course.services.VideoDownloadService;
 import in.testpress.database.TestpressDatabase;
+import in.testpress.testpress.BuildConfig;
 import in.testpress.testpress.Injector;
 import in.testpress.testpress.R;
 import in.testpress.testpress.R.id;
@@ -377,6 +378,7 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
 
         in.testpress.models.InstituteSettings settings =
                 new in.testpress.models.InstituteSettings(instituteSettings.getBaseUrl())
+                        .setWhiteLabeledHostUrl(BuildConfig.WHITE_LABELED_HOST_URL)
                         .setBookmarksEnabled(instituteSettings.getBookmarksEnabled())
                         .setCoursesFrontend(instituteSettings.getShowGameFrontend())
                         .setCoursesGamificationEnabled(instituteSettings.getCoursesEnableGamification())

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
@@ -231,6 +231,7 @@ class LoginActivityV2: ActionBarAccountAuthenticatorActivity(), LoginNavigationI
 
     private fun getInstituteSettings(): `in`.testpress.models.InstituteSettings {
         val settings = `in`.testpress.models.InstituteSettings(instituteSettings.baseUrl)
+            .setWhiteLabeledHostUrl(BuildConfig.WHITE_LABELED_HOST_URL)
             .setBookmarksEnabled(instituteSettings.bookmarksEnabled)
             .setCoursesFrontend(instituteSettings.showGameFrontend)
             .setCoursesGamificationEnabled(instituteSettings.coursesEnableGamification)

--- a/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
@@ -534,7 +534,6 @@ public class PostsListFragment extends Fragment implements
                 getLoaderManager().restartLoader(REFRESH_LOADER_ID, null, PostsListFragment.this);
                 categories.clear();
                 categoryPager.clear();
-                posts.clear();
                 fetchCategories();
             }
         });
@@ -568,8 +567,6 @@ public class PostsListFragment extends Fragment implements
                 Ln.e("Post category for " + post.getTitle() + " is null");
             }
         }
-        categoryDao.deleteAll();
-        postDao.deleteAll();
         categoryDao.insertOrReplaceInTx(categories);
         postDao.insertOrReplaceInTx(posts);
         LogAllPosts();

--- a/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
@@ -534,6 +534,7 @@ public class PostsListFragment extends Fragment implements
                 getLoaderManager().restartLoader(REFRESH_LOADER_ID, null, PostsListFragment.this);
                 categories.clear();
                 categoryPager.clear();
+                posts.clear();
                 fetchCategories();
             }
         });
@@ -567,6 +568,8 @@ public class PostsListFragment extends Fragment implements
                 Ln.e("Post category for " + post.getTitle() + " is null");
             }
         }
+        categoryDao.deleteAll();
+        postDao.deleteAll();
         categoryDao.insertOrReplaceInTx(categories);
         postDao.insertOrReplaceInTx(posts);
         LogAllPosts();

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
@@ -193,6 +193,7 @@ class UsernameAuthentication : BaseAuthenticationFragment() {
 
     private fun authenticate(userId: String, accessToken: String) {
         val settings = `in`.testpress.models.InstituteSettings(instituteSettings.baseUrl)
+            .setWhiteLabeledHostUrl(BuildConfig.WHITE_LABELED_HOST_URL)
             .setBookmarksEnabled(instituteSettings.bookmarksEnabled)
             .setCoursesFrontend(instituteSettings.showGameFrontend)
             .setCoursesGamificationEnabled(instituteSettings.coursesEnableGamification)

--- a/app/src/main/java/in/testpress/testpress/viewmodel/AutoLoginViewModel.kt
+++ b/app/src/main/java/in/testpress/testpress/viewmodel/AutoLoginViewModel.kt
@@ -5,6 +5,7 @@ import `in`.testpress.testpress.models.InstituteSettings
 import `in`.testpress.testpress.repository.TestPressSessionRepository
 import android.content.Context
 import androidx.lifecycle.ViewModel
+import `in`.testpress.testpress.BuildConfig
 
 class AutoLoginViewModel: ViewModel() {
 
@@ -14,6 +15,7 @@ class AutoLoginViewModel: ViewModel() {
 
     fun initializeTestPressSession(context: Context,instituteSettings: InstituteSettings, username: String, password: String, testPressService: TestpressService) {
         val settings = `in`.testpress.models.InstituteSettings(instituteSettings.baseUrl)
+                .setWhiteLabeledHostUrl(BuildConfig.WHITE_LABELED_HOST_URL)
                 .setBookmarksEnabled(instituteSettings.bookmarksEnabled)
                 .setCoursesFrontend(instituteSettings.showGameFrontend)
                 .setCoursesGamificationEnabled(instituteSettings.coursesEnableGamification)


### PR DESCRIPTION
### Issue:
- The white-labeled host URL was not being set in the InstituteSettings during various activities (e.g., CodeVerificationActivity, LoginActivity, UsernameAuthentication, etc.), leading to inconsistent configuration.
### Cause:
- The WHITE_LABELED_HOST_URL was not being initialized from BuildConfig in some key areas of the application.
### Fix:
- Added the setWhiteLabeledHostUrl(BuildConfig.WHITE_LABELED_HOST_URL) to ensure the white-labeled host URL is correctly initialized in the InstituteSettings object across multiple activities and view models.