### PR TITLE
fix: Resolve pagination issue in running content

### DIFF
--- a/app/src/main/java/in/testpress/testpress/core/PostService.java
+++ b/app/src/main/java/in/testpress/testpress/core/PostService.java
@@ -26,8 +26,7 @@ public interface PostService {
     @GET("/{posts_url}")
     TestpressApiResponse<Post> getPosts(
             @EncodedPath("posts_url") String postUrl,
-            @QueryMap Map<String, String> options,
-            @Header("If-Modified-Since") String latestModifiedDate
+            @QueryMap Map<String, String> options
     );
 
     @GET("/{forums_url}")

--- a/app/src/main/java/in/testpress/testpress/core/PostsPager.java
+++ b/app/src/main/java/in/testpress/testpress/core/PostsPager.java
@@ -19,7 +19,6 @@ import retrofit.RetrofitError;
 public class PostsPager extends ResourcePager<Post> {
 
     TestpressApiResponse<Post> response;
-    String latestModifiedDate;
     SimpleDateFormat simpleDateFormat;
     PostDao postDao;
 
@@ -56,7 +55,7 @@ public class PostsPager extends ResourcePager<Post> {
             }
         }
         if (url != null) {
-            response = service.getPosts(url, queryParams, latestModifiedDate);
+            response = service.getPosts(url, queryParams);
             return response.getResults();
         }
         return Collections.emptyList();
@@ -135,9 +134,5 @@ public class PostsPager extends ResourcePager<Post> {
 
     public int getTotalCount() {
         return response.getCount();
-    }
-
-    public void setLatestModifiedDate(String latestModifiedDate) {
-        this.latestModifiedDate = latestModifiedDate;
     }
 }

--- a/app/src/main/java/in/testpress/testpress/core/TestpressService.java
+++ b/app/src/main/java/in/testpress/testpress/core/TestpressService.java
@@ -153,10 +153,9 @@ public class TestpressService {
         return getDevicesService().register(credentials);
     }
 
-    public TestpressApiResponse<Post> getPosts(String urlFrag, Map<String, String> queryParams,
-                                               String latestModifiedDate) {
+    public TestpressApiResponse<Post> getPosts(String urlFrag, Map<String, String> queryParams) {
 
-        return getPostService().getPosts(urlFrag, queryParams, latestModifiedDate);
+        return getPostService().getPosts(urlFrag, queryParams);
     }
 
     public TestpressApiResponse<Forum> getForums(String urlFrag, Map<String, String> queryParams,

--- a/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
@@ -305,13 +305,6 @@ public class PostsListFragment extends Fragment implements
         if (refreshPager == null) {
             refreshPager = new PostsPager(getTestpressService(), postDao);
             refreshPager.setQueryParams("order", "-published_date");
-            if (postDao.count() > 0) {
-                Post latest = postDao.queryBuilder().orderDesc(PostDao.Properties.ModifiedDate)
-                        .list().get(0);
-                refreshPager.setLatestModifiedDate(latest.getModified());
-                LogLatestPostModifiedDate(latest);
-                LogAllPosts();
-            }
         }
     }
 
@@ -321,7 +314,6 @@ public class PostsListFragment extends Fragment implements
         Post lastPost = postDao.queryBuilder().orderDesc(PostDao.Properties
                 .Published).list().get((int) postDao.count() - 1);
         pager.setQueryParams("until", lastPost.getPublishedDate());
-        pager.setLatestModifiedDate(null);
     }
 
     @Override
@@ -361,6 +353,8 @@ public class PostsListFragment extends Fragment implements
         //If no data is available in the local database, directly insert
         //display from database
         Ln.e(swipeLayout.isRefreshing());
+        postDao.deleteAll();
+        categoryDao.deleteAll();
         if ((postDao.count() == 0) || items == null || items.isEmpty()) {
 
             //Remove the swipe refresh icon and the sticky notification if any
@@ -525,12 +519,6 @@ public class PostsListFragment extends Fragment implements
                 isUserSwiped = true;
                 refreshPager.clear();
                 refreshPager.setQueryParams("order", "-published_date");
-                if (postDao.count() > 0) {
-                    Post latest = postDao.queryBuilder().orderDesc(PostDao.Properties
-                            .ModifiedDate).list().get(0);
-                    refreshPager.setLatestModifiedDate(latest.getModified());
-                    LogLatestPostModifiedDate(latest);
-                }
                 getLoaderManager().restartLoader(REFRESH_LOADER_ID, null, PostsListFragment.this);
                 categories.clear();
                 categoryPager.clear();
@@ -654,13 +642,6 @@ public class PostsListFragment extends Fragment implements
             for (Post p : dbPosts)
                 Ln.d(p.getTitle() + " " + p.getPublishedDate() + "\n");
         }
-    }
-
-    void LogLatestPostModifiedDate(Post latest) {
-        Date date = new Date(latest.getModifiedDate());
-        Format format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        Ln.d("Latest post available is " + latest.getTitle()
-                + " modified on " + format.format(date) + " - " + latest.getModifiedDate());
     }
 
     @Override


### PR DESCRIPTION
### Issue:
- Previously, when a user refreshed posts, only new posts (based on the last modified date) were fetched, optimizing data retrieval.
- However, if an admin deleted a post, the deleted post remained in the local database since it wasn’t included in the fetch logic.
This caused inconsistencies between the server and local data.
### Fix:
- Removed last modified date filtering from post fetching logic.
- Now, on each refresh, all posts are fetched from the API, local posts are deleted, and the latest posts are stored.
