### PR TITLE
fix: Resolve GitHub Actions failures

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -32,7 +32,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Caching Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -52,7 +52,7 @@ jobs:
 
       - name: Cache Zoom SDK files
         id: zoom-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./mobilertc

--- a/.github/workflows/generate_debug_apk.yml
+++ b/.github/workflows/generate_debug_apk.yml
@@ -31,7 +31,7 @@ jobs:
           ruby-version: 2.7
 
       - name: Caching ruby dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: 'vendor/bundle'
           key: ${{ runner.os }}-gems-${{ secrets.GEMS_CACHE_VERSION }}-${{ hashFiles('**/Gemfile.lock') }}
@@ -40,7 +40,7 @@ jobs:
 
       - name: Cache Zoom SDK files
         id: zoom-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./mobilertc
@@ -54,7 +54,7 @@ jobs:
           unzip -o ./zoom_sdk.zip
 
       - name: Caching Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -40,7 +40,7 @@ jobs:
         uses: android-actions/setup-android@v2
 
       - name: Caching Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -60,7 +60,7 @@ jobs:
 
       - name: Cache Zoom SDK files
         id: zoom-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ./mobilertc


### PR DESCRIPTION
- GitHub actions were failing due to the deprecated `actions/cache@v2`.
- In this commit, we updated the action to `actions/cache@v3`, which resolves the issue.
