### PR TITLE
fix: Enable country code picker in mobile registration

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/fragments/AutoLoginFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/AutoLoginFragment.kt
@@ -20,6 +20,10 @@ open class AutoLoginFragment: RegistrationBaseFragment() {
     }
 
     override fun initViewModelObservers() {
+        binding.countryCodePicker.setOnCountryChangeListener {
+            viewModel.countryCode.value = binding.countryCodePicker.selectedCountryNameCode
+        }
+
         viewModel.isUserDataValid.observe(viewLifecycleOwner, Observer {
             if (it) {
                 register()

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/AutoLoginFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/AutoLoginFragment.kt
@@ -20,10 +20,6 @@ open class AutoLoginFragment: RegistrationBaseFragment() {
     }
 
     override fun initViewModelObservers() {
-        binding.countryCodePicker.setOnCountryChangeListener {
-            viewModel.countryCode.value = binding.countryCodePicker.selectedCountryNameCode
-        }
-
         viewModel.isUserDataValid.observe(viewLifecycleOwner, Observer {
             if (it) {
                 register()

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/RegistrationBaseFragment.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/RegistrationBaseFragment.kt
@@ -37,6 +37,7 @@ abstract class RegistrationBaseFragment: Fragment() {
         super.onViewCreated(view, savedInstanceState)
         initViewModel()
         initViewModelObservers()
+        initCounterCodePickerListener()
         hideErrorMessageOnTextChange()
         showPasswordToggleOnTextChange()
     }
@@ -51,6 +52,12 @@ abstract class RegistrationBaseFragment: Fragment() {
     }
 
     abstract fun initViewModelObservers()
+
+    private fun initCounterCodePickerListener(){
+        binding.countryCodePicker.setOnCountryChangeListener {
+            viewModel.countryCode.value = binding.countryCodePicker.selectedCountryNameCode
+        }
+    }
 
     fun onRegisterException(exception: Exception?) {
         binding.buttonRegister.isEnabled = true

--- a/app/src/main/java/in/testpress/testpress/viewmodel/RegisterViewModel.kt
+++ b/app/src/main/java/in/testpress/testpress/viewmodel/RegisterViewModel.kt
@@ -32,6 +32,7 @@ open class RegisterViewModel(
     val phoneNumber = MutableLiveData<String>()
     val password = MutableLiveData<String>()
     val confirmPassword = MutableLiveData<String>()
+    val countryCode = MutableLiveData<String>().apply { value = "IN" } // Default to India
 
     fun isUserDetailsValid() {
         val isValid = UserDataValidator(binding, verificationMethod, isTwilioEnabled).isValid()
@@ -51,7 +52,8 @@ open class RegisterViewModel(
                 username = username.value!!,
                 email = email.value!!,
                 password = password.value!!,
-                phoneNumber = phoneNumber.value!!
+                phoneNumber = phoneNumber.value!!,
+                countryCode = countryCode.value!!
         )
     }
 

--- a/app/src/main/res/layout-xlarge/register_activity.xml
+++ b/app/src/main/res/layout-xlarge/register_activity.xml
@@ -124,11 +124,10 @@
                             android:layout_marginRight="5dp"
                             android:background="@drawable/rounded_border_edittext"
                             android:paddingTop="10dp"
-                            app:ccp_autoDetectCountry="true"
-                            app:ccp_defaultNameCode="IND"
+                            app:ccp_countryPreference="in"
+                            android:visibility="visible"
                             app:ccp_showFlag="false"
-                            app:ccp_textSize="12sp"
-                            android:visibility="gone"/>
+                            app:ccp_textSize="12sp" />
 
                         <!-- Phone Label -->
                         <com.google.android.material.textfield.TextInputLayout

--- a/app/src/main/res/layout/register_activity.xml
+++ b/app/src/main/res/layout/register_activity.xml
@@ -125,9 +125,8 @@
                             android:layout_marginRight="5dp"
                             android:background="@drawable/rounded_border_edittext"
                             android:paddingTop="10dp"
-                            app:ccp_autoDetectCountry="true"
-                            app:ccp_defaultNameCode="IND"
-                            android:visibility="gone"
+                            app:ccp_countryPreference="in"
+                            android:visibility="visible"
                             app:ccp_showFlag="false"
                             app:ccp_textSize="12sp" />
 


### PR DESCRIPTION
- Previously, the country code option was not visible during mobile registration, forcing users to register with a default country code. This update makes the country code picker visible next to the phone number input field, allowing users to select their country code before entering their phone number.