### PR TITLE
fix: Show password reset alert when clicking Forgot Password

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -643,12 +643,7 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
     }
 
     @OnClick(id.forgot_password) public void verify() {
-        if(internetConnectivityChecker.isConnected()) {
-            Intent intent = new Intent(LoginActivity.this, ResetPasswordActivity.class);
-            startActivity(intent);
-        } else {
-            internetConnectivityChecker.showAlert();
-        }
+        showAlert("Please update your password at https://admissions.brilliantpala.org/ to continue");
     }
 
     @OnClick(id.google_sign_in_button) public void googleSignIn() {


### PR DESCRIPTION
- Previously, clicking Forgot Password opened `ResetPasswordActivity`.
- However, since Brilliant Pala does not use this functionality, we now display a message in an alert dialog instead.