### PR TITLE
feat: Add See All button to Course Carousel

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/view_holders/CourseCarouselViewHolder.java
+++ b/app/src/main/java/in/testpress/testpress/ui/view_holders/CourseCarouselViewHolder.java
@@ -9,7 +9,7 @@ import android.widget.TextView;
 
 import java.util.List;
 
-import in.testpress.course.ui.LeaderboardActivity;
+import in.testpress.course.ui.AvailableCoursesListActivity;
 import in.testpress.testpress.R;
 import in.testpress.testpress.models.pojo.DashboardResponse;
 import in.testpress.testpress.models.pojo.DashboardSection;
@@ -45,7 +45,7 @@ public class CourseCarouselViewHolder extends BaseCarouselViewHolder {
         seeAll.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent intent = new Intent(context, LeaderboardActivity.class);
+                Intent intent = new Intent(context, AvailableCoursesListActivity.class);
                 context.startActivity(intent);
             }
         });

--- a/app/src/main/java/in/testpress/testpress/ui/view_holders/CourseCarouselViewHolder.java
+++ b/app/src/main/java/in/testpress/testpress/ui/view_holders/CourseCarouselViewHolder.java
@@ -2,10 +2,14 @@ package in.testpress.testpress.ui.view_holders;
 
 import android.content.Context;
 import androidx.recyclerview.widget.LinearLayoutManager;
+
+import android.content.Intent;
 import android.view.View;
+import android.widget.TextView;
 
 import java.util.List;
 
+import in.testpress.course.ui.LeaderboardActivity;
 import in.testpress.testpress.R;
 import in.testpress.testpress.models.pojo.DashboardResponse;
 import in.testpress.testpress.models.pojo.DashboardSection;
@@ -13,8 +17,12 @@ import in.testpress.testpress.ui.adapters.CourseCarouselAdapter;
 
 
 public class CourseCarouselViewHolder extends BaseCarouselViewHolder {
+
+    TextView seeAll;
+
     public CourseCarouselViewHolder(View itemView, Context context) {
         super(itemView, context);
+        seeAll = itemView.findViewById(R.id.see_all);
     }
 
     public void display(DashboardResponse response, Context context) {
@@ -29,6 +37,18 @@ public class CourseCarouselViewHolder extends BaseCarouselViewHolder {
         if (section.getItems().size() > 2) {
             showPageIndicator();
         }
+        seeAll.setVisibility(View.VISIBLE);
+        initOnClickListeners(context);
+    }
+
+    private void initOnClickListeners(Context context) {
+        seeAll.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent intent = new Intent(context, LeaderboardActivity.class);
+                context.startActivity(intent);
+            }
+        });
     }
 
 }


### PR DESCRIPTION
- Added a `See All` button in CourseCarouselViewHolder to allow users to view the full product list.
- The button is now visible whenever a course carousel section is displayed.
- Clicking on 'See All' navigates the user to the Product list view.