### PR TITLE
fix: Correct hint assignment for username and password fields in LoginActivity

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -322,11 +322,11 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
     public void setLoginLabel(InstituteSettings instituteSettings) {
 
         if (!Strings.toString(in.testpress.testpress.util.UIUtils.getMenuItemName(R.string.label_username, instituteSettings)).isEmpty()) {
-            usernameInputLayout.setHint(in.testpress.testpress.util.UIUtils.getMenuItemName(R.string.label_username, instituteSettings));
+            usernameText.setHint(in.testpress.testpress.util.UIUtils.getMenuItemName(R.string.label_username, instituteSettings));
         }
 
         if (!Strings.toString(in.testpress.testpress.util.UIUtils.getMenuItemName(R.string.label_password, instituteSettings)).isEmpty()) {
-            passwordInputLayout.setHint(in.testpress.testpress.util.UIUtils.getMenuItemName(R.string.label_password, instituteSettings));
+            passwordText.setHint(in.testpress.testpress.util.UIUtils.getMenuItemName(R.string.label_password, instituteSettings));
         }
     }
 


### PR DESCRIPTION
- Updated setLoginLabel method to set hints on usernameText and passwordText instead of usernameInputLayout and passwordInputLayout.
- Ensures the correct UI elements display dynamic labels based on institute settings.
- Fixes potential UI inconsistency where the wrong elements were being updated with custom labels.
