### PR TITLE
refactor: Remove play and attachment icons from content carousel items

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/adapters/ContentsCarouselAdapter.java
+++ b/app/src/main/java/in/testpress/testpress/ui/adapters/ContentsCarouselAdapter.java
@@ -85,10 +85,8 @@ public class ContentsCarouselAdapter extends RecyclerView.Adapter<ContentsCarous
 
             showThumbnail(content, holder);
             setIconAndChapterTitle(content, holder);
-            showOrHideVideoAccessories(content, holder);
             showOrHideExamAccessories(content, holder);
             showReadTimeForHtmlContent(content, holder);
-            showIconForAttachmentContent(content, holder);
             showProgressBarForResumeVideos(position, holder);
 
 
@@ -112,8 +110,6 @@ public class ContentsCarouselAdapter extends RecyclerView.Adapter<ContentsCarous
         } else {
             showThumbnailForVideo(content, holder);
         }
-        holder.image.setColorFilter(Color.parseColor("#22000000"));
-
     }
 
     private void showThumbnailForVideo(Content content, ItemViewHolder holder) {
@@ -126,13 +122,6 @@ public class ContentsCarouselAdapter extends RecyclerView.Adapter<ContentsCarous
             } else {
                 holder.image.setBackgroundColor(Color.parseColor("#77000000"));
             }
-        }
-    }
-
-    private void showIconForAttachmentContent(Content content, ItemViewHolder holder) {
-        if (content.getAttachmentId() != null) {
-            holder.playIcon.setImageResource(R.drawable.ic_attachment);
-            holder.playIcon.setVisibility(View.VISIBLE);
         }
     }
 
@@ -193,15 +182,6 @@ public class ContentsCarouselAdapter extends RecyclerView.Adapter<ContentsCarous
         }
     }
 
-    private void showOrHideVideoAccessories(Content content, ItemViewHolder holder) {
-        if (content.getVideoId() != null) {
-            holder.playIcon.setVisibility(View.VISIBLE);
-            holder.playIcon.setImageResource(R.drawable.play);
-        } else {
-            holder.playIcon.setVisibility(View.GONE);
-        }
-    }
-
     private void showOrHideExamAccessories(Content content, ItemViewHolder holder) {
         if (content.getExamId() != null) {
             Exam exam = response.getExamHashMap().get(content.getExamId());
@@ -221,7 +201,7 @@ public class ContentsCarouselAdapter extends RecyclerView.Adapter<ContentsCarous
     }
 
     public class ItemViewHolder extends RecyclerView.ViewHolder {
-        ImageView image, playIcon, contentTypeIcon;
+        ImageView image, contentTypeIcon;
         TextView title, numberOfQuestions, subtitle, infoSubtitle;
         LinearLayout infoLayout, videoProgressLayout;
         ProgressBar videoProgress;
@@ -229,7 +209,6 @@ public class ContentsCarouselAdapter extends RecyclerView.Adapter<ContentsCarous
         public ItemViewHolder(View itemView) {
             super(itemView);
             image = (ImageView) itemView.findViewById(R.id.image_view);
-            playIcon = (ImageView) itemView.findViewById(R.id.play_icon);
             contentTypeIcon = (ImageView) itemView.findViewById(R.id.content_type_icon);
             infoLayout = (LinearLayout) itemView.findViewById(R.id.info_layout);
             videoProgressLayout = (LinearLayout) itemView.findViewById(R.id.video_progress_layout);

--- a/app/src/main/res/layout/content_carousel_item.xml
+++ b/app/src/main/res/layout/content_carousel_item.xml
@@ -25,15 +25,6 @@
             android:scaleType="centerCrop"
             android:background="@drawable/border_rectangle_light" />
 
-        <ImageView
-            android:id="@+id/play_icon"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            android:layout_gravity="center_horizontal|center_vertical"
-            android:paddingBottom="10dp"
-            android:src="@drawable/play"
-            android:visibility="gone" />
-
         <LinearLayout
             android:layout_width="155dp"
             android:layout_height="wrap_content"


### PR DESCRIPTION
- This PR cleans up the ContentsCarouselAdapter by removing unused UI elements and associated logic for displaying play and attachment icons in the content carousel:
- Removed playIcon view and its references from both the adapter and the layout.
- Deleted methods showOrHideVideoAccessories and showIconForAttachmentContent, which are no longer used.
- Removed related color filter logic from showThumbnail.
- This helps simplify the adapter and reduces UI clutter for content items that no longer require these icons.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the play icon overlay from carousel items, simplifying the display for content in the carousel.
  - Updated the carousel layout to no longer include the play icon image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->