### PR TITLE
feat: Enable Jetpack Compose support in the app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,6 +102,18 @@ dependencies {
     implementation 'com.github.mhiew:android-pdf-viewer:3.2.0-beta.1'
     implementation 'com.github.alexto9090:PRDownloader:1.0'
     implementation 'com.salesforce.marketingcloud:marketingcloudsdk:8.0.7'
+
+    def composeBom = platform('androidx.compose:compose-bom:2024.08.00')
+    implementation(composeBom)
+    androidTestImplementation(composeBom)
+
+    implementation "androidx.compose.runtime:runtime"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.foundation:foundation"
+    implementation "androidx.compose.foundation:foundation-layout"
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.compose.runtime:runtime-livedata"
+    implementation "androidx.compose.ui:ui-tooling"
 }
 
 def key_alias = "sample"
@@ -135,6 +147,11 @@ android {
 
     buildFeatures {
         viewBinding true
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.4.1'
     }
 
     compileOptions {


### PR DESCRIPTION
- Compose-based UIs could not be built due to missing configuration and dependencies.
- This blocked the introduction of newer UI screens that rely on Jetpack Compose.
- This is fixed by enabling Compose in build features and adding required Compose libraries and BOM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to enable Jetpack Compose support, allowing for modern UI development features in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->