### PR TITLE
Update testpressSDK to 1.4.198 and downgrade Compose BOM to 2023.09.01

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 ext {
-    testpressSDK = '1.4.197'
+    testpressSDK = '1.4.198'
 }
 
 def jsonFile = file('src/main/assets/config.json')
@@ -103,7 +103,7 @@ dependencies {
     implementation 'com.github.alexto9090:PRDownloader:1.0'
     implementation 'com.salesforce.marketingcloud:marketingcloudsdk:8.0.7'
 
-    def composeBom = platform('androidx.compose:compose-bom:2024.08.00')
+    def composeBom = platform('androidx.compose:compose-bom:2023.09.01')
     implementation(composeBom)
     androidTestImplementation(composeBom)
 


### PR DESCRIPTION
- Downgraded `androidx.compose:compose-bom` from `2024.08.00` to `2023.09.01`.
- Upgraded `testpressSDK` version from `1.4.197` to `1.4.198`.
- The newer Compose BOM was incompatible with `testpressSDK` v1.4.198. Downgrading the Compose version ensures compatibility between the app and the SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of the testpressSDK dependency.
  - Adjusted the Compose BOM platform version used in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->