### PR TITLE
fix: Apply webview theme to EnforceDataActivity for date picker visibility

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -235,7 +235,7 @@
             android:configChanges="orientation|keyboardHidden|screenSize"/>
 
         <activity android:name=".ui.EnforceDataActivity"
-            android:theme="@style/AppTheme"
+            android:theme="@style/TestpressWebViewTheme"
             android:configChanges="orientation|keyboardHidden|screenSize"/>
 
     </application>


### PR DESCRIPTION
- In the earlier commit 4a15e657595f987206eeb7b4559f219383a8652c, we introduced a separate theme `TestpressWebViewTheme` for `WebViewActivity` to address an issue where the date picker's text was not visible due to white text on a white background.
- In this commit, we apply the same `TestpressWebViewTheme` to `EnforceDataActivity`, which also uses a date picker in some cases. This ensures consistency and resolves the visibility issue in the date picker UI for this activity as well.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the visual theme of a specific activity for a refreshed appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->