### PR TITLE
fix: Hide forgot password container after successful password reset

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/ResetPasswordActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/ResetPasswordActivity.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.GravityEnum;
@@ -37,6 +38,7 @@ public class ResetPasswordActivity extends FragmentActivity {
     @InjectView(R.id.form) LinearLayout formContainer;
     @InjectView(R.id.success_complete) LinearLayout successContainer;
     private final TextWatcher watcher = validationTextWatcher();
+    private RelativeLayout forgotPasswordContainer;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -46,6 +48,7 @@ public class ResetPasswordActivity extends FragmentActivity {
         ButterKnife.inject(this);
         resetErrorMessage = R.string.reset_error_message;
         email.addTextChangedListener(watcher);
+        forgotPasswordContainer = findViewById(R.id.forgot_password_container);
     }
 
     @OnClick(R.id.b_reset_password) public void reset(){
@@ -81,6 +84,7 @@ public class ResetPasswordActivity extends FragmentActivity {
                     progressDialog.dismiss();
                     formContainer.setVisibility(View.GONE);
                     successContainer.setVisibility(View.VISIBLE);
+                    forgotPasswordContainer.setVisibility(View.GONE);
                 }
             }.execute();
         }

--- a/app/src/main/res/layout/activity_reset_password.xml
+++ b/app/src/main/res/layout/activity_reset_password.xml
@@ -13,6 +13,7 @@
         app:layout_constraintGuide_percent="0.5" />
 
     <RelativeLayout
+        android:id="@+id/forgot_password_container"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_marginHorizontal="30dp"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the password reset process by ensuring the "Forgot Password" section is hidden after a successful password reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->