### PR TITLE
feat: Add offline attachment downloads sync support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 ext {
-    testpressSDK = '1.4.215'
+    testpressSDK = '1.4.216'
 }
 
 def jsonFile = file('src/main/assets/config.json')

--- a/app/src/main/java/in/testpress/testpress/TestpressApplication.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressApplication.java
@@ -19,6 +19,7 @@ import in.testpress.testpress.models.DaoSession;
 import in.testpress.testpress.models.InstituteSettings;
 import in.testpress.testpress.models.InstituteSettingsDao;
 import static in.testpress.testpress.BuildConfig.BASE_URL;
+import in.testpress.testpress.util.ApplicationKt;
 import in.testpress.testpress.util.NotificationHelper;
 
 public class TestpressApplication extends Application {
@@ -60,6 +61,7 @@ public class TestpressApplication extends Application {
         DaoMaster daoMaster = new DaoMaster(db);
         daoSession = daoMaster.newSession();
         NotificationHelper.createChannels(this);
+        ApplicationKt.syncDownloads(this);
     }
 
     public static AppComponent getAppComponent() {

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -1,5 +1,8 @@
 package in.testpress.testpress.ui;
 import in.testpress.RequestCode;
+import in.testpress.course.fragments.OfflineDownloadsTabsFragment;
+import in.testpress.course.repository.OfflineAttachmentsRepository;
+import in.testpress.course.services.OfflineAttachmentDownloadManager;
 import in.testpress.course.ui.AvailableCourseListFragment;
 import in.testpress.course.ui.CourseListFragment;
 
@@ -59,6 +62,7 @@ import in.testpress.course.repository.VideoWatchDataRepository;
 import in.testpress.course.ui.MyCoursesFragment;
 import in.testpress.database.OfflineVideoDao;
 import in.testpress.database.TestpressDatabase;
+import in.testpress.database.dao.OfflineAttachmentsDao;
 import in.testpress.exam.ui.view.NonSwipeableViewPager;
 import in.testpress.testpress.BuildConfig;
 import in.testpress.testpress.R;
@@ -155,6 +159,7 @@ public class MainActivity extends TestpressFragmentActivity {
             checkUpdate();
         }
         setupEasterEgg();
+        initOfflineAttachmentDownloadManager();
     }
 
     @Override
@@ -218,6 +223,13 @@ public class MainActivity extends TestpressFragmentActivity {
             }
         });
         versionInfo.setActionView(button);
+    }
+
+    private void initOfflineAttachmentDownloadManager() {
+        OfflineAttachmentsDao offlineAttachmentDao = TestpressDatabase.Companion.invoke(this).offlineAttachmentDao();
+        OfflineAttachmentsRepository offlineAttachmentsRepository =new OfflineAttachmentsRepository(offlineAttachmentDao);
+        OfflineAttachmentDownloadManager.Companion.init(offlineAttachmentsRepository);
+        OfflineAttachmentDownloadManager.Companion.getInstance().restartDownloadProgressTracking(this);
     }
 
     private void setUpNavigationDrawer() {
@@ -416,8 +428,8 @@ public class MainActivity extends TestpressFragmentActivity {
                         TestpressCourse.getLeaderboardFragment(this, TestpressSdk.getTestpressSession(this)));
             }
             if (mInstituteSettings.getIsVideoDownloadEnabled()) {
-                DownloadsFragment downloadsFragment = new DownloadsFragment();
-                addMenuItem(R.string.downloads, R.drawable.ic_downloads, downloadsFragment);
+                OfflineDownloadsTabsFragment offlineDownloadsTabsFragment = new OfflineDownloadsTabsFragment();
+                addMenuItem(R.string.downloads, R.drawable.ic_downloads, offlineDownloadsTabsFragment);
             }
         } else {
             grid.setVisibility(View.GONE);
@@ -738,8 +750,10 @@ public class MainActivity extends TestpressFragmentActivity {
                     Manifest.permission.READ_MEDIA_VIDEO
             }, RequestCode.PERMISSION);
         } else {
-            requestPermissions(new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, RequestCode.PERMISSION);
-
+            requestPermissions(new String[]{
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+            }, RequestCode.PERMISSION);
         }
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -750,9 +750,7 @@ public class MainActivity extends TestpressFragmentActivity {
                     Manifest.permission.READ_MEDIA_VIDEO
             }, RequestCode.PERMISSION);
         } else {
-            requestPermissions(new String[]{
-                    Manifest.permission.WRITE_EXTERNAL_STORAGE
-            }, RequestCode.PERMISSION);
+            requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, RequestCode.PERMISSION);
         }
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -751,6 +751,7 @@ public class MainActivity extends TestpressFragmentActivity {
             }, RequestCode.PERMISSION);
         } else {
             requestPermissions(new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, RequestCode.PERMISSION);
+
         }
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -751,7 +751,6 @@ public class MainActivity extends TestpressFragmentActivity {
             }, RequestCode.PERMISSION);
         } else {
             requestPermissions(new String[]{
-                    Manifest.permission.READ_EXTERNAL_STORAGE,
                     Manifest.permission.WRITE_EXTERNAL_STORAGE
             }, RequestCode.PERMISSION);
         }

--- a/app/src/main/java/in/testpress/testpress/util/Application.kt
+++ b/app/src/main/java/in/testpress/testpress/util/Application.kt
@@ -19,7 +19,7 @@ fun Application.syncDownloads() {
                 OfflineAttachmentSyncManager(this@syncDownloads.applicationContext, dao)
             syncManager.syncDownloads()
         } catch (e: Exception) {
-            Log.e("SampleApplication", "Failed to sync downloads", e)
+            Log.e("DownloadSync", "Failed to sync downloads", e)
         }
     }
 }

--- a/app/src/main/java/in/testpress/testpress/util/Application.kt
+++ b/app/src/main/java/in/testpress/testpress/util/Application.kt
@@ -1,0 +1,25 @@
+package `in`.testpress.testpress.util
+
+import android.app.Application
+import android.util.Log
+import `in`.testpress.course.helpers.OfflineAttachmentSyncManager
+import `in`.testpress.database.TestpressDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+
+fun Application.syncDownloads() {
+    CoroutineScope(Dispatchers.IO + SupervisorJob()).launch {
+        try {
+            val dao = TestpressDatabase.invoke(this@syncDownloads.applicationContext)
+                .offlineAttachmentDao()
+            val syncManager =
+                OfflineAttachmentSyncManager(this@syncDownloads.applicationContext, dao)
+            syncManager.syncDownloads()
+        } catch (e: Exception) {
+            Log.e("SampleApplication", "Failed to sync downloads", e)
+        }
+    }
+}


### PR DESCRIPTION
- Updated the application to initialize and sync offline attachment downloads on app startup. Introduced a Kotlin extension function to handle syncing logic during application initialization.
- Replaced the legacy DownloadsFragment with a new OfflineDownloadsTabsFragment to support the updated attachment download flow.
- Also added required storage permissions and initialized the download manager in MainActivity to restart progress tracking across sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced offline attachment download management, including synchronization of downloads during app startup and improved tracking of download progress.
  * Updated the downloads section in the app to use a new offline downloads tabbed interface.

* **Improvements**
  * Enhanced permission requests for storage access on older Android versions to ensure smoother offline functionality.

* **Chores**
  * Upgraded the testpressSDK dependency to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->