### PR TITLE
fix: Upgrade to AGP 8.2.2 and Gradle 8.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,8 +135,8 @@ try {
 android {
 
     compileSdkVersion 34
-    buildToolsVersion '30.0.3'
-    ndkVersion "23.2.8568313"
+    buildToolsVersion '34.0.0'
+    ndkVersion "25.1.8937393"
     namespace 'in.testpress.testpress'
 
     dataBinding {
@@ -144,6 +144,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig true
         viewBinding true
         compose true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath 'com.google.gms:google-services:4.3.14'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Sep 28 15:30:07 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- The project is being updated to support Android Gradle Plugin (AGP) 8.2.2 and Gradle 8.2, which are required for compatibility with the latest Android Studio versions and tooling improvements.
- AGP 8.x introduces stricter resource scoping and new build APIs, which require adjustments in module configuration and resource usage.
- This change upgrades:

> 1. Gradle wrapper from 7.5 to 8.2
> 2. Android Gradle Plugin from 7.4.2 to 8.2.2
> 3. Build tools version to 34.0.0
> 4. NDK version to 25.1.8937393

- buildConfig generation is explicitly enabled to support AGP 8.x defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android build tools, NDK, and Gradle versions to newer releases.
  * Enabled additional build configuration options for improved build processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->