### PR TITLE
refactor: Replace switch with safe Kotlin mapping for menu labels

### DIFF
--- a/app/src/main/java/in/testpress/testpress/util/UIUtils.java
+++ b/app/src/main/java/in/testpress/testpress/util/UIUtils.java
@@ -78,30 +78,7 @@ public class UIUtils {
     }
 
     public static String getMenuItemName(int titleResId, InstituteSettings instituteSettings) {
-        switch (titleResId) {
-            case R.string.dashboard:
-                return Strings.toString(instituteSettings.getDashboardLabel());
-            case R.string.leaderboard:
-                return Strings.toString(instituteSettings.getLeaderboardLabel());
-            case R.string.bookmarks:
-                return Strings.toString(instituteSettings.getBookmarksLabel());
-            case R.string.documents:
-                return Strings.toString(instituteSettings.getDocumentsLabel());
-            case R.string.store:
-                return Strings.toString(instituteSettings.getStoreLabel());
-            case R.string.posts:
-                return Strings.toString(instituteSettings.getPostsLabel());
-            case R.string.learn:
-                return Strings.toString(instituteSettings.getLearnLabel());
-            case R.string.label_username:
-                return Strings.toString(instituteSettings.getLoginLabel());
-            case R.string.label_password:
-                return Strings.toString(instituteSettings.getLoginPasswordLabel());
-            case R.string.discussions:
-                return Strings.toString(instituteSettings.getForumLabel());
-            default:
-                return "";
-        }
+        return UIUtilsKt.getMenuItemName(titleResId, instituteSettings);
     }
 
     public static Typeface getLatoSemiBoldFont(@NonNull Context context) {

--- a/app/src/main/java/in/testpress/testpress/util/UIUtils.kt
+++ b/app/src/main/java/in/testpress/testpress/util/UIUtils.kt
@@ -1,0 +1,20 @@
+package `in`.testpress.testpress.util
+
+import `in`.testpress.testpress.R
+import `in`.testpress.testpress.models.InstituteSettings
+
+fun getMenuItemName(titleResId: Int, instituteSettings: InstituteSettings): String {
+    return when (titleResId) {
+        R.string.dashboard -> Strings.toString(instituteSettings.dashboardLabel)
+        R.string.leaderboard -> Strings.toString(instituteSettings.leaderboardLabel)
+        R.string.bookmarks -> Strings.toString(instituteSettings.bookmarksLabel)
+        R.string.documents -> Strings.toString(instituteSettings.documentsLabel)
+        R.string.store -> Strings.toString(instituteSettings.storeLabel)
+        R.string.posts -> Strings.toString(instituteSettings.postsLabel)
+        R.string.learn -> Strings.toString(instituteSettings.learnLabel)
+        R.string.label_username -> Strings.toString(instituteSettings.loginLabel)
+        R.string.label_password -> Strings.toString(instituteSettings.loginPasswordLabel)
+        R.string.discussions -> Strings.toString(instituteSettings.forumLabel)
+        else -> ""
+    }
+}

--- a/app/src/main/java/in/testpress/testpress/util/UIUtils.kt
+++ b/app/src/main/java/in/testpress/testpress/util/UIUtils.kt
@@ -3,8 +3,8 @@ package `in`.testpress.testpress.util
 import `in`.testpress.testpress.R
 import `in`.testpress.testpress.models.InstituteSettings
 
-fun getMenuItemName(titleResId: Int, instituteSettings: InstituteSettings): String {
-    return when (titleResId) {
+fun getMenuItemName(titleResId: Int, instituteSettings: InstituteSettings): String =
+    when (titleResId) {
         R.string.dashboard -> Strings.toString(instituteSettings.dashboardLabel)
         R.string.leaderboard -> Strings.toString(instituteSettings.leaderboardLabel)
         R.string.bookmarks -> Strings.toString(instituteSettings.bookmarksLabel)
@@ -17,4 +17,3 @@ fun getMenuItemName(titleResId: Int, instituteSettings: InstituteSettings): Stri
         R.string.discussions -> Strings.toString(instituteSettings.forumLabel)
         else -> ""
     }
-}


### PR DESCRIPTION
- Menu label resolution used a switch on R.string.* values, which are no longer final in Android Gradle Plugin 8.0 and above. [Ref](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes)
- This caused build-time issues and made the code unsafe for future compatibility.
- The logic is now safely delegated to a Kotlin when expression via getMenuItemName() in a new Kotlin file. This improves readability and maintains forward compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the way menu item labels are determined by centralizing the label resolution logic, leading to more maintainable and consistent behavior across the app. No visible changes to app features or user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->