### PR TITLE
fix: Build error due to incompatible desugar_jdk_libs version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     implementation "androidx.compose.ui:ui-tooling"
 
     implementation "com.google.android.material:material:1.8.0"
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 }
 
 def key_alias = "sample"


### PR DESCRIPTION
- The build was failing with a `mergeExtDexDebug` error during dexing.
- This occurred because the newer version of `desugar_jdk_libs` (2.1.5) was incompatible with certain libraries like bcprov-jdk15to18, causing dexing to fail.
- The issue is resolved by reverting to `desugar_jdk_libs:2.0.4`, which is compatible and allows the dexing process to 
complete successfully.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s build configuration to use an earlier version of a library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->