### PR TITLE
fix: Ensure consistent system bar appearance with Android 15 edge-to-edge changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 ext {
-    testpressSDK = '1.4.218'
+    testpressSDK = '1.4.219'
 }
 
 def jsonFile = file('src/main/assets/config.json')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 ext {
-    testpressSDK = '1.4.217'
+    testpressSDK = '1.4.218'
 }
 
 def jsonFile = file('src/main/assets/config.json')

--- a/app/src/main/java/in/testpress/testpress/TestpressApplication.java
+++ b/app/src/main/java/in/testpress/testpress/TestpressApplication.java
@@ -19,6 +19,7 @@ import in.testpress.testpress.models.DaoSession;
 import in.testpress.testpress.models.InstituteSettings;
 import in.testpress.testpress.models.InstituteSettingsDao;
 import static in.testpress.testpress.BuildConfig.BASE_URL;
+import in.testpress.testpress.util.ActivityLifecycleCallbacksKt;
 import in.testpress.testpress.util.ApplicationKt;
 import in.testpress.testpress.util.NotificationHelper;
 
@@ -62,6 +63,7 @@ public class TestpressApplication extends Application {
         daoSession = daoMaster.newSession();
         NotificationHelper.createChannels(this);
         ApplicationKt.syncDownloads(this);
+        registerActivityLifecycleCallbacks(ActivityLifecycleCallbacksKt.getActivityLifecycleCallbacks());
     }
 
     public static AppComponent getAppComponent() {

--- a/app/src/main/java/in/testpress/testpress/util/ActivityLifecycleCallbacks.kt
+++ b/app/src/main/java/in/testpress/testpress/util/ActivityLifecycleCallbacks.kt
@@ -7,7 +7,7 @@ import `in`.testpress.util.applySystemBarColors
 
 val activityLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        activity.applySystemBarColors(activity.window.decorView.rootView)
+        activity.applySystemBarColors(activity.window.decorView)
     }
 
     override fun onActivityStarted(activity: Activity) {}

--- a/app/src/main/java/in/testpress/testpress/util/ActivityLifecycleCallbacks.kt
+++ b/app/src/main/java/in/testpress/testpress/util/ActivityLifecycleCallbacks.kt
@@ -1,0 +1,20 @@
+package `in`.testpress.testpress.util
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import `in`.testpress.util.applySystemBarColors
+
+val activityLifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        activity.applySystemBarColors(activity.window.decorView.rootView)
+    }
+
+    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityResumed(activity: Activity) {}
+    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivityStopped(activity: Activity) {}
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+    override fun onActivityDestroyed(activity: Activity) {}
+
+}


### PR DESCRIPTION
- On Android 15, system bars were not styled correctly in some activities, resulting in inconsistent UI and a broken visual experience.
- This happened because edge-to-edge mode is enforced by default in Android 15, and system bar styling was handled manually in individual activities.
- This is fixed by registering a global ActivityLifecycleCallbacks to apply system bar colors automatically when any activity is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System bar colors are now automatically applied to all activities when they are created, ensuring a consistent appearance throughout the app.

* **Chores**
  * Updated the Testpress SDK to version 1.4.218.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->