### PR TITLE
chore: update compile and target SDK to 35

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,8 +134,7 @@ try {
 
 android {
 
-    compileSdkVersion 34
-    buildToolsVersion '34.0.0'
+    compileSdkVersion 35
     ndkVersion "25.1.8937393"
     namespace 'in.testpress.testpress'
 
@@ -175,7 +174,7 @@ android {
 
     defaultConfig {
         minSdkVersion 23
-        targetSdkVersion 34
+        targetSdkVersion 35
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         versionName json.version


### PR DESCRIPTION
- The app was using SDK 34, which may cause compatibility issues with the latest Android versions and Play Store requirements.
- This happened because the project had not been updated to align with the latest Android SDK release.
- Updated both compile and target SDK versions to 35 to ensure compatibility and future-proof the app.