### PR TITLE
fix: handle custom errors after network and authorization checks

### DIFF
--- a/app/src/main/java/in/testpress/testpress/core/RestErrorHandler.java
+++ b/app/src/main/java/in/testpress/testpress/core/RestErrorHandler.java
@@ -35,22 +35,20 @@ public class RestErrorHandler implements ErrorHandler {
 
     @Override
     public Throwable handleError(RetrofitError cause) {
-        TestpressApiErrorResponse errorResponse = (TestpressApiErrorResponse) cause.getBodyAs(TestpressApiErrorResponse.class);
-
-        if (errorResponse.getErrorCode() != null) {
-            bus.post(new CustomErrorEvent(errorResponse.getErrorCode(), errorResponse.getDetail()));
-        }
-
         if(cause != null) {
             if (cause.isNetworkError()) {
                 bus.post(new NetworkErrorEvent(cause));
-            } else if(isUnAuthorized(cause)) {
+            } else if (isUnAuthorized(cause)) {
                 bus.post(new UnAuthorizedErrorEvent(cause));
-            } else if(isUnAuthorizedUser(cause)) {
+            } else if (isUnAuthorizedUser(cause)) {
                 bus.post(new UnAuthorizedUserErrorEvent());
-            }
-            else {
-                bus.post(new RestAdapterErrorEvent(cause));
+            } else {
+                TestpressApiErrorResponse errorResponse = (TestpressApiErrorResponse) cause.getBodyAs(TestpressApiErrorResponse.class);
+                if (errorResponse != null && errorResponse.getErrorCode() != null) {
+                    bus.post(new CustomErrorEvent(errorResponse.getErrorCode(), errorResponse.getDetail()));
+                } else {
+                    bus.post(new RestAdapterErrorEvent(cause));
+                }
             }
         }
 


### PR DESCRIPTION
- Previously, custom errors were processed before network and authorization checks.
- If parsing the API response failed, important errors such as network or unauthorized errors were not correctly reported.
- This is fixed by processing network and authorization errors first, and handling custom errors only afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved rare crashes when server responses lacked error details.
  * Improved reliability of error messages by using server-provided details when available.
  * Added safe fallback to generic errors when details are missing, preventing app hangs.
  * Maintained consistent behavior for offline and unauthorized states.
  * Ensured more consistent error notifications without changing user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->