### PR TITLE
fix: Allow offline access when enforce data is enabled

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -722,7 +722,7 @@ public class MainActivity extends TestpressFragmentActivity {
                         @Override
                         public void onClick(View v) {
                             emptyView.setVisibility(View.GONE);
-                            fetchInstituteSettings();
+                            checkForForceUserData();
                         }
                     });
                 }


### PR DESCRIPTION
- When the enforce data feature was enabled, users could not access the app in offline mode.
- This happened because network errors were always handled by showing an error state, blocking access to offline features.
- The fix ensures that internet-related exceptions no longer trigger the error state, allowing users to access downloaded videos and attachments while offline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to avoid unnecessary UI updates during transient connectivity issues.
  * Standardized error messaging to “Try again after some time” for non-network failures.
  * Added consistent retry behavior: hides the placeholder view and retries loading when tapped.
  * Ensured app content is hidden before displaying error states for a cleaner experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->