### PR TITLE
feat: Enforce branch validation for special subdomains in release workflow

### DIFF
--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -34,9 +34,11 @@ jobs:
           SPECIAL_SUBDOMAINS="brilliantpalalms brilliantpalaelearn race"
           if echo "$SPECIAL_SUBDOMAINS" | grep -w "$SUBDOMAIN" > /dev/null; then
             if [ "$BRANCH_NAME" != "$SUBDOMAIN" ]; then
-              echo "Error: For subdomain '$SUBDOMAIN', workflow must run on branch '$SUBDOMAIN'. Current branch is '$BRANCH_NAME'."
-              echo "This is because the '$SUBDOMAIN' institute has a customized UI maintained in a separate branch named '$SUBDOMAIN'."
-              echo "Please merge the latest changes from 'master' into the '$SUBDOMAIN' branch and run this release update from that branch."
+              RED='\033[0;31m'
+              NC='\033[0m' # No Color
+              echo -e "${RED}ERROR: For subdomain '$SUBDOMAIN', workflow must run on branch '$SUBDOMAIN'. Current branch is '$BRANCH_NAME'.${NC}"
+              echo -e "${RED}This is because the '$SUBDOMAIN' institute has a customized UI maintained in a separate branch named '$SUBDOMAIN'.${NC}"
+              echo -e "${RED}Please merge the latest changes from 'master' into the '$SUBDOMAIN' branch and run this release update from that branch.${NC}"
               exit 1
             fi
           else


### PR DESCRIPTION
- Some institutes (e.g., brilliantpalalms, brilliantpalaelearn, race) have customized UIs maintained in separate branches matching their subdomain names.
- Previously, release updates could be triggered from any branch, which risked deploying changes from the wrong branch for these institutes.
- This update enforces validation so that release updates for special subdomains must run on their corresponding branch. For other subdomains, releases can still run from any branch.