### PR TITLE
ci: Automate subdomain extraction in build workflow

### DIFF
--- a/.github/actions/extract-subdomain/action.yml
+++ b/.github/actions/extract-subdomain/action.yml
@@ -1,0 +1,18 @@
+name: "Extract Subdomain"
+description: "Extracts the subdomain from a given URL or comma-separated URLs"
+inputs:
+  url:
+    description: "The URL or comma-separated URLs to process"
+    required: true
+outputs:
+  subdomain:
+    description: "The extracted subdomain(s), comma-separated if multiple"
+    value: ${{ steps.extract.outputs.result }}
+runs:
+  using: "composite"
+  steps:
+    - name: Run extraction script
+      id: extract
+      shell: bash
+      run: |
+        ${{ github.action_path }}/../../scripts/extract_subdomain.sh "${{ inputs.url }}"

--- a/.github/scripts/extract_subdomain.sh
+++ b/.github/scripts/extract_subdomain.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+INPUT_URLS=$1
+if [[ -z "$INPUT_URLS" ]]; then
+  echo "Error: No URL(s) provided"
+  exit 1
+fi
+
+# Split by comma and handle each URL
+IFS=',' read -ra ADDR <<< "$INPUT_URLS"
+SUBDOMAINS=()
+
+for URL in "${ADDR[@]}"; do
+  # Trim whitespace
+  URL=$(echo "$URL" | xargs)
+  if [[ -z "$URL" ]]; then continue; fi
+
+  # Strip protocol and trailing paths
+  CLEAN_URL=$(echo "$URL" | sed -e 's|^[^/]*//||' -e 's|/.*$||')
+  echo "Processing URL: $CLEAN_URL"
+
+  if [[ "$CLEAN_URL" == *".testpress.in" ]]; then
+    FINAL_URL="$CLEAN_URL"
+  else
+    # Get CNAME lookup
+    DIG_RESULT=$(dig "$CLEAN_URL" CNAME +short 2>/dev/null | sed 's/\.$//')
+    FINAL_URL=$(echo "$DIG_RESULT" | grep "testpress.in" | head -n 1)
+  fi
+
+  if [[ -z "$FINAL_URL" ]]; then
+    echo "::error::Could not determine testpress subdomain for $URL"
+    exit 1
+  fi
+
+  SUBDOMAIN=$(echo "$FINAL_URL" | cut -d'.' -f1)
+  echo "Extracted Subdomain: $SUBDOMAIN"
+  SUBDOMAINS+=("$SUBDOMAIN")
+done
+
+# Join with comma
+RESULT=$(IFS=, ; echo "${SUBDOMAINS[*]}")
+echo "result=$RESULT" >> $GITHUB_OUTPUT
+echo "SUBDOMAIN=$RESULT" >> $GITHUB_ENV
+# For backward compatibility if single subdomain is expected in SUBDOMAINS env
+echo "SUBDOMAINS=$RESULT" >> $GITHUB_ENV

--- a/.github/scripts/extract_subdomain.sh
+++ b/.github/scripts/extract_subdomain.sh
@@ -39,6 +39,7 @@ done
 
 # Join with comma
 RESULT=$(IFS=, ; echo "${SUBDOMAINS[*]}")
+echo "Final Subdomains List: $RESULT"
 echo "result=$RESULT" >> $GITHUB_OUTPUT
 echo "SUBDOMAIN=$RESULT" >> $GITHUB_ENV
 # For backward compatibility if single subdomain is expected in SUBDOMAINS env

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -26,29 +26,9 @@ jobs:
 
     steps:
       - name: Extract subdomain
-        id: extract_subdomain
-        run: |
-          URL="${{ github.event.inputs.url }}"
-          # Strip protocol (http:// or https://) and any trailing paths
-          CLEAN_URL=$(echo "$URL" | sed -e 's|^[^/]*//||' -e 's|/.*$||')
-          echo "Processing URL: $CLEAN_URL"
-
-          if [[ "$CLEAN_URL" == *".testpress.in" ]]; then
-            FINAL_URL="$CLEAN_URL"
-          else
-            # Get CNAME and pick the first one matching testpress.in
-            DIG_RESULT=$(dig "$CLEAN_URL" CNAME +short | sed 's/\.$//')
-            FINAL_URL=$(echo "$DIG_RESULT" | grep "testpress.in" | head -n 1)
-          fi
-
-          if [[ -z "$FINAL_URL" ]]; then
-            echo "Error: Could not determine testpress subdomain for $URL"
-            exit 1
-          fi
-
-          SUBDOMAIN=$(echo "$FINAL_URL" | cut -d'.' -f1)
-          echo "Extracted Subdomain: $SUBDOMAIN"
-          echo "SUBDOMAIN=$SUBDOMAIN" >> $GITHUB_ENV
+        uses: ./.github/actions/extract-subdomain
+        with:
+          url: ${{ github.event.inputs.url }}
 
       - name: Validate subdomain
         run: |

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -25,6 +25,9 @@ jobs:
       API_ACCESS_KEY: ${{ secrets.API_ACCESS_KEY }}
 
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
       - name: Extract subdomain
         uses: ./.github/actions/extract-subdomain
         with:
@@ -52,9 +55,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-
-      - name: Checkout the repository
-        uses: actions/checkout@v2
 
       - name: Setup ruby and fastlane
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -3,10 +3,10 @@ name: Bulid app files
 on:
   workflow_dispatch:
     inputs:
-      subdomain:
-        description: "Which subdomain you want to build the android app"
+      url:
+        description: "URL of the site (e.g., subdomain.testpress.in or custom domain)"
         required: true
-        default: "sandbox"
+        default: "sandbox.testpress.in"
       split_apk:
         description: "Build split APKs by ABI?"
         required: false
@@ -25,9 +25,34 @@ jobs:
       API_ACCESS_KEY: ${{ secrets.API_ACCESS_KEY }}
 
     steps:
+      - name: Extract subdomain
+        id: extract_subdomain
+        run: |
+          URL="${{ github.event.inputs.url }}"
+          # Strip protocol (http:// or https://) and any trailing paths
+          CLEAN_URL=$(echo "$URL" | sed -e 's|^[^/]*//||' -e 's|/.*$||')
+          echo "Processing URL: $CLEAN_URL"
+
+          if [[ "$CLEAN_URL" == *".testpress.in" ]]; then
+            FINAL_URL="$CLEAN_URL"
+          else
+            # Get CNAME and pick the first one matching testpress.in
+            DIG_RESULT=$(dig "$CLEAN_URL" CNAME +short | sed 's/\.$//')
+            FINAL_URL=$(echo "$DIG_RESULT" | grep "testpress.in" | head -n 1)
+          fi
+
+          if [[ -z "$FINAL_URL" ]]; then
+            echo "Error: Could not determine testpress subdomain for $URL"
+            exit 1
+          fi
+
+          SUBDOMAIN=$(echo "$FINAL_URL" | cut -d'.' -f1)
+          echo "Extracted Subdomain: $SUBDOMAIN"
+          echo "SUBDOMAIN=$SUBDOMAIN" >> $GITHUB_ENV
+
       - name: Validate subdomain
         run: |
-          curl -f https://${{ github.event.inputs.subdomain }}.testpress.in/api/v2.5/admin/android/app-config/ -H "API-access-key: $API_ACCESS_KEY"
+          curl -f https://$SUBDOMAIN.testpress.in/api/v2.5/admin/android/app-config/ -H "API-access-key: $API_ACCESS_KEY"
 
       - name: Setup JDK 17
         uses: actions/setup-java@v3
@@ -76,7 +101,7 @@ jobs:
         run: |
           export LC_ALL=en_US.UTF-8
           export LANG=en_US.UTF-8
-          bundle exec fastlane build_app_files subdomain:${{ github.event.inputs.subdomain }} split_apk:${{ github.event.inputs.split_apk }}
+          bundle exec fastlane build_app_files subdomain:$SUBDOMAIN split_apk:${{ github.event.inputs.split_apk }}
 
       - name: Store app artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -32,6 +32,9 @@ jobs:
       API_ACCESS_KEY: ${{ secrets.API_ACCESS_KEY }}
 
     steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
       - name: Validate inputs
         run: |
           MODE="${{ github.event.inputs.mode }}"
@@ -61,9 +64,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-
-      - name: Checkout the repository
-        uses: actions/checkout@v2
 
       - name: Setup ruby and fastlane
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -10,8 +10,8 @@ on:
         options:
           - "all"
           - "batch"
-      subdomains:
-        description: "Batch mode only: comma-separated subdomains (example: inst1,inst2,inst3). Can contain a single subdomain."
+      urls:
+        description: "Batch mode only: comma-separated URLs (example: https://inst1.testpress.in, https://customdomain.com). Can contain a single URL."
         required: false
         default: ""
 
@@ -35,10 +35,10 @@ jobs:
       - name: Validate inputs
         run: |
           MODE="${{ github.event.inputs.mode }}"
-          SUBDOMAINS="${{ github.event.inputs.subdomains }}"
+          URLS="${{ github.event.inputs.urls }}"
           if [ "$MODE" = "batch" ]; then
-            if [ -z "$(echo "$SUBDOMAINS" | tr -d '[:space:]')" ]; then
-              echo "ERROR: mode=batch requires non-empty 'subdomains' input (comma-separated)."
+            if [ -z "$(echo "$URLS" | tr -d '[:space:]')" ]; then
+              echo "ERROR: mode=batch requires non-empty 'urls' input (comma-separated)."
               exit 1
             fi
           fi
@@ -86,6 +86,12 @@ jobs:
           wget https://media.testpress.in/static/android/zoom_sdk.zip
           unzip -o ./zoom_sdk.zip
 
+      - name: Extract subdomains
+        if: ${{ github.event.inputs.mode == 'batch' }}
+        uses: ./.github/actions/extract-subdomain
+        with:
+          url: ${{ github.event.inputs.urls }}
+
       - name: Build and deploy app (all)
         if: ${{ github.event.inputs.mode == 'all' }}
         run: |
@@ -98,7 +104,7 @@ jobs:
         run: |
           export LC_ALL=en_US.UTF-8
           export LANG=en_US.UTF-8
-          bundle exec fastlane release_update_batch subdomains:"${{ github.event.inputs.subdomains }}" release_option:${{ github.event.inputs.release_option }}
+          bundle exec fastlane release_update_batch subdomains:"$SUBDOMAINS" release_option:${{ github.event.inputs.release_option }}
 
       - name: Store app artifacts
         if: ${{ github.event.inputs.mode == 'all' }}


### PR DESCRIPTION
- Implement a reusable subdomain extraction system that supports both direct  Testpress subdomains and white-labeled custom domains via CNAME lookup
- Create a composite GitHub Action and supporting bash script to handle both single-site builds and batch release processing
- Update 'build_app.yml' and 'release_update.yml' to accept site URLs  instead of manual subdomains
- Rename the 'Bulid app files' workflow to 'Generate App' for a more  generic naming convention