### PR TITLE
feat: Handle UPI payment URLs in WebView

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/CustomWebViewFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/CustomWebViewFragment.java
@@ -1,0 +1,102 @@
+package in.testpress.testpress.ui;
+
+import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+import in.testpress.testpress.core.Constants;
+
+@SuppressLint("SetJavaScriptEnabled")
+public class CustomWebViewFragment extends Fragment {
+
+    private WebView webView;
+    public static final String ARG_EMAIL = "email";
+    public static final String ARG_PASS = "pass";
+
+    public static CustomWebViewFragment newInstance(String email, String pass) {
+        CustomWebViewFragment fragment = new CustomWebViewFragment();
+        Bundle args = new Bundle();
+        args.putString(ARG_EMAIL, email);
+        args.putString(ARG_PASS, pass);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Nullable
+    @Override
+    public android.view.View onCreateView(@NonNull android.view.LayoutInflater inflater, @Nullable android.view.ViewGroup container, @Nullable Bundle savedInstanceState) {
+        webView = new WebView(requireContext());
+        
+        webView.getSettings().setJavaScriptEnabled(true);
+        webView.getSettings().setDomStorageEnabled(true);
+        webView.getSettings().setDatabaseEnabled(true);
+        webView.getSettings().setAllowFileAccess(true);
+        webView.getSettings().setAllowContentAccess(true);
+        
+        webView.setWebViewClient(new WebViewClient() {
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                String url = request.getUrl().toString();
+                return handleUpiUrl(url, view);
+            }
+            
+            @Override
+            public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                return handleUpiUrl(url, view);
+            }
+            
+            private boolean handleUpiUrl(String url, WebView view) {
+                if (url.startsWith("upi://") || url.contains("upi://") || 
+                    url.startsWith("gpay://") || url.startsWith("phonepe://") || 
+                    url.startsWith("paytm://")) {
+                    try {
+                        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                        if (view.getContext().getPackageManager().resolveActivity(intent, 0) != null) {
+                            view.getContext().startActivity(intent);
+                        } else {
+                            Toast.makeText(view.getContext(), "No UPI app found", Toast.LENGTH_SHORT).show();
+                        }
+                    } catch (Exception e) {
+                        Toast.makeText(view.getContext(), "No UPI app found", Toast.LENGTH_SHORT).show();
+                    }
+                    return true;
+                }
+                return false;
+            }
+        });
+        
+        String url = Constants.Http.EPRATIBHA_SSO_URL;
+        if (getArguments() != null) {
+            String email = getArguments().getString(ARG_EMAIL, "");
+            String pass = getArguments().getString(ARG_PASS, "");
+            if (!email.isEmpty()) {
+                url += "?email=" + email + "&pass=" + pass;
+            }
+        }
+        webView.loadUrl(url);
+        
+        return webView;
+    }
+    
+    @Override
+    public void onDestroyView() {
+        if (webView != null) {
+            webView.destroy();
+        }
+        super.onDestroyView();
+    }
+}

--- a/app/src/main/java/in/testpress/testpress/ui/CustomWebViewFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/CustomWebViewFragment.java
@@ -19,16 +19,23 @@ import in.testpress.testpress.core.Constants;
 public class CustomWebViewFragment extends Fragment {
 
     private WebView webView;
+    
+    public static final String ARG_URL_TO_OPEN = "url_to_open";
     public static final String ARG_EMAIL = "email";
     public static final String ARG_PASS = "pass";
 
-    public static CustomWebViewFragment newInstance(String email, String pass) {
+    public static CustomWebViewFragment newInstance(String url, String email, String pass) {
         CustomWebViewFragment fragment = new CustomWebViewFragment();
         Bundle args = new Bundle();
+        args.putString(ARG_URL_TO_OPEN, url);
         args.putString(ARG_EMAIL, email);
         args.putString(ARG_PASS, pass);
         fragment.setArguments(args);
         return fragment;
+    }
+
+    public static CustomWebViewFragment newInstance(String email, String pass) {
+        return newInstance(Constants.Http.EPRATIBHA_SSO_URL, email, pass);
     }
 
     @Override
@@ -44,8 +51,8 @@ public class CustomWebViewFragment extends Fragment {
         webView.getSettings().setJavaScriptEnabled(true);
         webView.getSettings().setDomStorageEnabled(true);
         webView.getSettings().setDatabaseEnabled(true);
-        webView.getSettings().setAllowFileAccess(true);
-        webView.getSettings().setAllowContentAccess(true);
+        webView.getSettings().setAllowFileAccess(false);
+        webView.getSettings().setAllowContentAccess(false);
         
         webView.setWebViewClient(new WebViewClient() {
             @Override
@@ -60,9 +67,10 @@ public class CustomWebViewFragment extends Fragment {
             }
             
             private boolean handleUpiUrl(String url, WebView view) {
-                if (url.startsWith("upi://") || url.contains("upi://") || 
-                    url.startsWith("gpay://") || url.startsWith("phonepe://") || 
-                    url.startsWith("paytm://")) {
+                Uri uri = Uri.parse(url);
+                String scheme = uri.getScheme();
+                if ("upi".equals(scheme) || "gpay".equals(scheme) || 
+                    "phonepe".equals(scheme) || "paytm".equals(scheme)) {
                     try {
                         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
                         if (view.getContext().getPackageManager().resolveActivity(intent, 0) != null) {
@@ -79,15 +87,23 @@ public class CustomWebViewFragment extends Fragment {
             }
         });
         
-        String url = Constants.Http.EPRATIBHA_SSO_URL;
+        String baseUrl = Constants.Http.EPRATIBHA_SSO_URL;
         if (getArguments() != null) {
+            if (getArguments().containsKey(ARG_URL_TO_OPEN)) {
+                baseUrl = getArguments().getString(ARG_URL_TO_OPEN, Constants.Http.EPRATIBHA_SSO_URL);
+            }
             String email = getArguments().getString(ARG_EMAIL, "");
             String pass = getArguments().getString(ARG_PASS, "");
             if (!email.isEmpty()) {
-                url += "?email=" + email + "&pass=" + pass;
+                Uri uri = Uri.parse(baseUrl)
+                        .buildUpon()
+                        .appendQueryParameter("email", email)
+                        .appendQueryParameter("pass", pass)
+                        .build();
+                baseUrl = uri.toString();
             }
         }
-        webView.loadUrl(url);
+        webView.loadUrl(baseUrl);
         
         return webView;
     }

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -525,7 +525,11 @@ public class MainActivity extends TestpressFragmentActivity {
 
     private void addEPratibhaWebViewFragment() {
         String[] credentials = CommonUtils.getUserCredentials(this);
-        CustomWebViewFragment customWebViewFragment = CustomWebViewFragment.newInstance(credentials[0], credentials[1]);
+        CustomWebViewFragment customWebViewFragment = CustomWebViewFragment.newInstance(
+                Constants.Http.EPRATIBHA_SSO_URL, 
+                credentials[0], 
+                credentials[1]
+        );
         addMenuItem(R.string.store, R.drawable.home_store_image, customWebViewFragment);
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -525,15 +525,8 @@ public class MainActivity extends TestpressFragmentActivity {
 
     private void addEPratibhaWebViewFragment() {
         String[] credentials = CommonUtils.getUserCredentials(this);
-        WebViewFragment webViewFragment = new WebViewFragment();
-        Bundle bundle = new Bundle();
-        bundle.putString(WebViewFragment.URL_TO_OPEN, Constants.Http.EPRATIBHA_SSO_URL + "?email=" + credentials[0] + "&pass=" + credentials[1]);
-        bundle.putBoolean(WebViewFragment.SHOW_LOADING_BETWEEN_PAGES, true);
-        bundle.putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, false);
-        bundle.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, true);
-        bundle.putBoolean(WebViewFragment.ENABLE_SWIPE_REFRESH, true);
-        webViewFragment.setArguments(bundle);
-        addMenuItem(R.string.store, R.drawable.home_store_image, webViewFragment);
+        CustomWebViewFragment customWebViewFragment = CustomWebViewFragment.newInstance(credentials[0], credentials[1]);
+        addMenuItem(R.string.store, R.drawable.home_store_image, customWebViewFragment);
     }
 
     private void onItemSelected(int position) {


### PR DESCRIPTION
This PR introduces a new CustomWebViewFragment to handle loading the EPratibha SSO page with enhanced WebView capabilities.

**Key changes:**
- Added a new fragment: CustomWebViewFragment
- Enabled WebView configurations:
	- JavaScript, DOM storage, and database support
	- Restricted file and content access for better security
	- Implemented UPI deep link handling inside WebView:
	- Detects UPI-related schemes (upi://, gpay://, phonepe://, paytm://)
	- Opens corresponding external UPI apps via Intent
	- Shows fallback message if no UPI app is available
	- Supports passing email and password as query params for SSO login
	- Replaced existing WebViewFragment usage in MainActivity with CustomWebViewFragment