### PR TITLE
fix: Prevent duplicate categories in post list spinner on refresh

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
@@ -235,6 +235,9 @@ public class PostsListFragment extends Fragment implements
             }
 
             protected void onSuccess(final List<Category> categories) throws Exception {
+                if (getActivity() == null) {
+                    return;
+                }
                 categoryDao.insertOrReplaceInTx(categories);
                 initializeSpinnerAdapter();
                 for (final Category category : categories) {

--- a/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
+++ b/app/src/main/java/in/testpress/testpress/ui/PostsListFragment.java
@@ -111,8 +111,7 @@ public class PostsListFragment extends Fragment implements
         TestpressApplication.getAppComponent().inject(this);
         mTopLevelSpinnerAdapter = new ExploreSpinnerAdapter(getActivity().getLayoutInflater(),
                 getActivity().getResources(), true);
-        mTopLevelSpinnerAdapter.addItem("", getString(R.string.all_posts), false, 0);
-        mTopLevelSpinnerAdapter.addHeader(getString(R.string.categories));
+        initializeSpinnerAdapter();
         Toolbar toolbar;
         if (getActivity() instanceof MainActivity) {
             toolbar = ((MainActivity) (getActivity())).getActionBarToolbar();
@@ -237,6 +236,7 @@ public class PostsListFragment extends Fragment implements
 
             protected void onSuccess(final List<Category> categories) throws Exception {
                 categoryDao.insertOrReplaceInTx(categories);
+                initializeSpinnerAdapter();
                 for (final Category category : categories) {
                     mTopLevelSpinnerAdapter.addItem("" + category.getId(), category.getName(), true,
                             Color.parseColor("#" + category.getColor()));
@@ -268,6 +268,12 @@ public class PostsListFragment extends Fragment implements
             }
 
         }.execute();
+    }
+
+    private void initializeSpinnerAdapter() {
+        mTopLevelSpinnerAdapter.clear();
+        mTopLevelSpinnerAdapter.addItem("", getString(R.string.all_posts), false, 0);
+        mTopLevelSpinnerAdapter.addHeader(getString(R.string.categories));
     }
 
     @SuppressLint("StaticFieldLeak")


### PR DESCRIPTION
- What was the issue? 
	- When the post categories were refreshed or reloaded, they were being appended to the existing list in the spinner, leading to duplicate entries for "All Posts" and individual categories.
- What caused the issue? 
	- The ExploreSpinnerAdapter was not cleared before adding the updated list of categories in the onSuccess callback.
- How is it fixed? 
	- Extracted the spinner initialization logic into initializeSpinnerAdapter(), which now explicitly calls clear() before adding the "All Posts" item and "Categories" header. This method is now called before repopulating the categories.