### PR TITLE
fix: Safely handle enableSplitApk gradle property comparison

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,7 +162,7 @@ android {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
-    def enableSplitApk = project.hasProperty('enableSplitApk') && project.property('enableSplitApk') == 'true'
+    def enableSplitApk = project.hasProperty('enableSplitApk') && project.property('enableSplitApk').toString() == 'true'
     splits {
         abi {
             enable enableSplitApk


### PR DESCRIPTION
Fixed the `enableSplitApk` property comparison by converting the Gradle property value to a string before checking against `"true"`.

## Changes

* Added `.toString()` while reading the `enableSplitApk` property
* Ensures consistent boolean comparison across different Gradle environments

## Why

Gradle properties may not always be returned directly as a `String`. This change prevents unexpected comparison issues during build configuration.
