### PR TITLE
ci: Add workflow to clean up old GitHub Actions artifacts

### DIFF
--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -87,6 +87,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app
+          retention-days: 7
           path: |
             app/build/outputs/apk/release/*.apk
             app/build/outputs/bundle/release/app-release.aab

--- a/.github/workflows/cleanup_artifacts.yml
+++ b/.github/workflows/cleanup_artifacts.yml
@@ -1,7 +1,6 @@
 name: Cleanup old artifacts
 
 on:
-  pull_request:
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:

--- a/.github/workflows/cleanup_artifacts.yml
+++ b/.github/workflows/cleanup_artifacts.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   cleanup:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Delete old artifacts
         uses: actions/github-script@v7

--- a/.github/workflows/cleanup_artifacts.yml
+++ b/.github/workflows/cleanup_artifacts.yml
@@ -58,3 +58,4 @@ jobs:
             }
 
             core.info(`Deleted ${deletedCount} artifact(s). Kept ${keptCount} artifact(s).`);
+

--- a/.github/workflows/cleanup_artifacts.yml
+++ b/.github/workflows/cleanup_artifacts.yml
@@ -1,0 +1,59 @@
+name: Cleanup old artifacts
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      days_to_keep:
+        description: "Delete artifacts older than this many days"
+        required: false
+        default: "7"
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  cleanup:
+    runs-on: self-hosted
+    steps:
+      - name: Delete old artifacts
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const daysToKeep = Number(core.getInput('days_to_keep') || '7');
+
+            if (!Number.isInteger(daysToKeep) || daysToKeep < 1) {
+              throw new Error('days_to_keep must be a positive integer');
+            }
+
+            const cutoff = new Date(Date.now() - daysToKeep * 24 * 60 * 60 * 1000);
+            let deletedCount = 0;
+            let keptCount = 0;
+
+            for await (const response of github.paginate.iterator(
+              github.rest.actions.listArtifactsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              }
+            )) {
+              for (const artifact of response.data) {
+                if (new Date(artifact.created_at) >= cutoff) {
+                  keptCount += 1;
+                  continue;
+                }
+
+                await github.rest.actions.deleteArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: artifact.id,
+                });
+                deletedCount += 1;
+                core.info(`Deleted artifact ${artifact.name} (${artifact.id}) from ${artifact.created_at}`);
+              }
+            }
+
+            core.info(`Deleted ${deletedCount} artifact(s). Kept ${keptCount} artifact(s).`);

--- a/.github/workflows/cleanup_artifacts.yml
+++ b/.github/workflows/cleanup_artifacts.yml
@@ -1,6 +1,7 @@
 name: Cleanup old artifacts
 
 on:
+  pull_request:
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:

--- a/.github/workflows/generate_debug_apk.yml
+++ b/.github/workflows/generate_debug_apk.yml
@@ -85,4 +85,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app
+          retention-days: 7
           path: app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/release_update.yml
+++ b/.github/workflows/release_update.yml
@@ -111,6 +111,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: app
+          retention-days: 7
           path: |
             app/build/outputs/apk/release/app-release.apk
             app/build/outputs/bundle/release/app-release.aab
@@ -121,6 +122,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: batch-app-artifacts
+          retention-days: 7
           path: |
             batch_artifacts
 
@@ -129,5 +131,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: batch-summary
+          retention-days: 7
           path: |
             release_update_batch_summary.json


### PR DESCRIPTION
- GitHub Actions artifacts were being retained for the repository's default duration, unnecessarily consuming storage space.
- This occurred because there was no routine cleanup process or explicit retention policy configured.
- Fixed by introducing a scheduled `cleanup_artifacts.yml` workflow to automatically purge artifacts older than 7 days nightly. Additionally, explicitly set `retention-days: 7` on all `actions/upload-artifact` steps across existing workflows as a safeguard.