### PR TITLE
feat: Redirect users to custom forgot password URL

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -5,6 +5,7 @@ import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Bundle;
@@ -663,10 +664,19 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
 
     private void verify() {
         if(internetConnectivityChecker.isConnected()) {
-            if (instituteSettings != null && instituteSettings.getCustomForgotPasswordUrl() != null && !instituteSettings.getCustomForgotPasswordUrl().isEmpty()) {
-                Intent intent = new Intent(Intent.ACTION_VIEW, android.net.Uri.parse(instituteSettings.getCustomForgotPasswordUrl()));
-                startActivity(intent);
-            } else {
+            boolean openedCustomUrl = false;
+            if (instituteSettings != null && instituteSettings.hasCustomForgotPasswordUrl()) {
+                try {
+                    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(instituteSettings.getCustomForgotPasswordUrl()));
+                    startActivity(intent);
+                    openedCustomUrl = true;
+                } catch (android.content.ActivityNotFoundException e) {
+                    android.widget.Toast.makeText(getApplicationContext(),
+                            "No suitable app was found to open this URL. Please install any browser app",
+                            android.widget.Toast.LENGTH_SHORT).show();
+                }
+            }
+            if (!openedCustomUrl) {
                 Intent intent = new Intent(LoginActivity.this, ResetPasswordActivity.class);
                 startActivity(intent);
             }

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -663,8 +663,13 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
 
     private void verify() {
         if(internetConnectivityChecker.isConnected()) {
-            Intent intent = new Intent(LoginActivity.this, ResetPasswordActivity.class);
-            startActivity(intent);
+            if (instituteSettings != null && instituteSettings.getCustomForgotPasswordUrl() != null && !instituteSettings.getCustomForgotPasswordUrl().isEmpty()) {
+                Intent intent = new Intent(Intent.ACTION_VIEW, android.net.Uri.parse(instituteSettings.getCustomForgotPasswordUrl()));
+                startActivity(intent);
+            } else {
+                Intent intent = new Intent(LoginActivity.this, ResetPasswordActivity.class);
+                startActivity(intent);
+            }
         } else {
             internetConnectivityChecker.showAlert();
         }

--- a/app/src/main/java/in/testpress/testpress/models/InstituteSettings.java
+++ b/app/src/main/java/in/testpress/testpress/models/InstituteSettings.java
@@ -784,6 +784,10 @@ public class InstituteSettings {
     public Boolean getEnableOfflineExam(Context context) {
         return AppChecker.INSTANCE.isLmsDemoApp(context);
     }
+
+    public boolean hasCustomForgotPasswordUrl() {
+        return customForgotPasswordUrl != null && !customForgotPasswordUrl.isEmpty();
+    }
     // KEEP METHODS END
 
 }

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
@@ -23,6 +23,7 @@ import android.accounts.AccountManager
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -108,6 +109,16 @@ class UsernameAuthentication : BaseAuthenticationFragment() {
             loginNavigation?.goToPhoneAuthentication()
         }
 
+        binding.forgotPassword.setOnClickListener {
+            if (instituteSettings != null && !instituteSettings.customForgotPasswordUrl.isNullOrEmpty()) {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(instituteSettings.customForgotPasswordUrl))
+                startActivity(intent)
+            } else {
+                val intent = Intent(requireContext(), ResetPasswordActivity::class.java)
+                requireActivity().startActivity(intent)
+            }
+        }
+
         binding.signIn.setOnClickListener {
             if (binding.username.isEmpty() or binding.password.isEmpty()) {
                 if (binding.username.isEmpty()) {
@@ -121,10 +132,6 @@ class UsernameAuthentication : BaseAuthenticationFragment() {
             }
         }
 
-        binding.forgotPassword.setOnClickListener {
-            val intent = Intent(requireContext(), ResetPasswordActivity::class.java)
-            requireActivity().startActivity(intent)
-        }
 
         binding.googleSignIn.setOnClickListener {
             loginNavigation?.signInWithGoogle()

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
@@ -110,10 +110,21 @@ class UsernameAuthentication : BaseAuthenticationFragment() {
         }
 
         binding.forgotPassword.setOnClickListener {
-            if (instituteSettings != null && !instituteSettings.customForgotPasswordUrl.isNullOrEmpty()) {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(instituteSettings.customForgotPasswordUrl))
-                startActivity(intent)
-            } else {
+            var openedCustomUrl = false
+            if (instituteSettings != null && instituteSettings.hasCustomForgotPasswordUrl()) {
+                try {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(instituteSettings.customForgotPasswordUrl))
+                    startActivity(intent)
+                    openedCustomUrl = true
+                } catch (e: android.content.ActivityNotFoundException) {
+                    android.widget.Toast.makeText(
+                        requireContext(),
+                        "No suitable app was found to open this URL. Please install any browser app",
+                        android.widget.Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+            if (!openedCustomUrl) {
                 val intent = Intent(requireContext(), ResetPasswordActivity::class.java)
                 requireActivity().startActivity(intent)
             }


### PR DESCRIPTION
- Check for a custom forgot password URL in institute settings when the user requests a password reset
- If a custom URL is configured, open it in an external web browser
- Otherwise, fall back to the default local password reset activity