### PR TITLE
build: Release Testpress SDK version 1.4.286

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 ext {
-    testpressSDK = '1.4.284'
+    testpressSDK = '1.4.286'
 }
 
 def jsonFile = file('src/main/assets/config.json')

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -2,7 +2,7 @@ package in.testpress.testpress.ui;
 import in.testpress.RequestCode;
 import in.testpress.course.fragments.OfflineDownloadsTabsFragment;
 import in.testpress.course.repository.OfflineAttachmentsRepository;
-import in.testpress.course.services.OfflineAttachmentDownloadManager;
+import in.testpress.course.services.NewOfflineAttachmentDownloadManager;
 import in.testpress.course.ui.AvailableCourseListFragment;
 import in.testpress.course.ui.CourseListFragment;
 
@@ -276,8 +276,8 @@ public class MainActivity extends TestpressFragmentActivity {
     private void initOfflineAttachmentDownloadManager() {
         OfflineAttachmentsDao offlineAttachmentDao = TestpressDatabase.Companion.invoke(this).offlineAttachmentDao();
         OfflineAttachmentsRepository offlineAttachmentsRepository =new OfflineAttachmentsRepository(offlineAttachmentDao);
-        OfflineAttachmentDownloadManager.Companion.init(offlineAttachmentsRepository);
-        OfflineAttachmentDownloadManager.Companion.getInstance().restartDownloadProgressTracking(this);
+        NewOfflineAttachmentDownloadManager.Companion.init(offlineAttachmentsRepository);
+        NewOfflineAttachmentDownloadManager.Companion.getInstance().restartDownloadProgressTracking(this);
     }
 
     private void setUpNavigationDrawer() {


### PR DESCRIPTION
Update the project dependencies to use the latest Testpress SDK version and migrate offline
attachment download management to the new manager.
- Upgrade the testpressSDK dependency version from 1.4.284 to 1.4.286.
- Replace usage of OfflineAttachmentDownloadManager with NewOfflineAttachmentDownloadManager
  in MainActivity to support the updated SDK implementation.