### PR TITLE
refactor: Migrate activities to OnBackPressedDispatcher API

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
@@ -13,6 +13,7 @@ import android.os.CountDownTimer;
 import android.provider.Settings;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.activity.OnBackPressedCallback;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.KeyEvent;
@@ -131,7 +132,7 @@ public class CodeVerificationActivity extends AppCompatActivity {
             }
         });
         accountManager = AccountManager.get(this);
-        getOnBackPressedDispatcher().addCallback(this, new androidx.activity.OnBackPressedCallback(true) {
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
             @Override
             public void handleOnBackPressed() {
                 if (username == null) {
@@ -352,8 +353,6 @@ public class CodeVerificationActivity extends AppCompatActivity {
                 })
                 .show();
     }
-
-
 
     private void fetchInstituteSettingLocalDB() {
         DaoSession daoSession = ((TestpressApplication) getApplicationContext()).getDaoSession();

--- a/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/CodeVerificationActivity.java
@@ -131,6 +131,16 @@ public class CodeVerificationActivity extends AppCompatActivity {
             }
         });
         accountManager = AccountManager.get(this);
+        getOnBackPressedDispatcher().addCallback(this, new androidx.activity.OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (username == null) {
+                    Intent intent = new Intent(CodeVerificationActivity.this, MainActivity.class);
+                    startActivity(intent);
+                    finish();
+                }
+            }
+        });
     }
 
     private void bindViews() {
@@ -343,14 +353,7 @@ public class CodeVerificationActivity extends AppCompatActivity {
                 .show();
     }
 
-    @Override
-    public void onBackPressed() {
-        if(username == null) { //onBackPressed go to login screen only if username is null
-            Intent intent = new Intent(CodeVerificationActivity.this, MainActivity.class);
-            startActivity(intent);
-            finish();
-        }
-    }
+
 
     private void fetchInstituteSettingLocalDB() {
         DaoSession daoSession = ((TestpressApplication) getApplicationContext()).getDaoSession();

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
@@ -29,6 +29,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
@@ -71,6 +72,17 @@ class LoginActivityV2: ActionBarAccountAuthenticatorActivity(), LoginNavigationI
         initializeViewModel()
         fetchInstituteSettings()
         initializeGoogleSignIn()
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (supportFragmentManager.backStackEntryCount == 1) {
+                    finish()
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                    isEnabled = true
+                }
+            }
+        })
     }
 
     private fun initializeViewModel() {
@@ -185,13 +197,6 @@ class LoginActivityV2: ActionBarAccountAuthenticatorActivity(), LoginNavigationI
     }
 
 
-    override fun onBackPressed() {
-        if (supportFragmentManager.backStackEntryCount == 1) {
-            finish()
-        } else {
-            super.onBackPressed()
-        }
-    }
 
     private fun googleSignInAuthentication(result: GoogleSignInResult) {
         val userId = result.signInAccount!!.getId()

--- a/app/src/main/java/in/testpress/testpress/ui/BaseToolBarActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/BaseToolBarActivity.java
@@ -33,7 +33,7 @@ public abstract class BaseToolBarActivity extends AppCompatActivity {
                 startActivity(intent);
                 finish();
             } else {
-                onBackPressed();
+                getOnBackPressedDispatcher().onBackPressed();
             }
             return true;
         }

--- a/app/src/main/java/in/testpress/testpress/ui/DeviceNotAllowedActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/DeviceNotAllowedActivity.java
@@ -2,6 +2,7 @@ package in.testpress.testpress.ui;
 
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.activity.OnBackPressedCallback;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
@@ -53,11 +54,12 @@ public class DeviceNotAllowedActivity extends AppCompatActivity {
                 serviceProvider.logout(DeviceNotAllowedActivity.this, testpressService, serviceProvider, logoutService);
             }
         });
-    }
-
-    @Override
-    public void onBackPressed() {
-        // Disable back button to force user to logout
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                // Disable back button to force user to logout
+            }
+        });
     }
 
     public static void resetShowing() {

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -20,6 +20,8 @@ import android.os.Build;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.activity.OnBackPressedCallback;
+import androidx.appcompat.widget.Toolbar;
 import androidx.annotation.Nullable;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.core.view.GravityCompat;
@@ -156,6 +158,27 @@ public class MainActivity extends TestpressFragmentActivity {
         }
         setupEasterEgg();
         initOfflineAttachmentDownloadManager();
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (shouldHandleWebViewBackPress()) {
+                    handleWebViewBackPress();
+                    return;
+                }
+
+                if (courseListFragment != null && viewPager.getCurrentItem() == 1) {
+                    if (courseListFragment.onBackPress()) {
+                        viewPager.setCurrentItem(0);
+                    }
+                } else if (viewPager.getCurrentItem() != 0) {
+                    viewPager.setCurrentItem(0);
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                    setEnabled(true);
+                }
+            }
+        });
     }
 
     private void bindViews() {
@@ -173,23 +196,6 @@ public class MainActivity extends TestpressFragmentActivity {
     }
 
 
-    @Override
-    public void onBackPressed() {
-        if (shouldHandleWebViewBackPress()) {
-            handleWebViewBackPress();
-            return;
-        }
-
-        if (courseListFragment != null && viewPager.getCurrentItem() == 1) {
-            if (courseListFragment.onBackPress()) {
-                viewPager.setCurrentItem(0);
-            }
-        } else if (viewPager.getCurrentItem() != 0) {
-            viewPager.setCurrentItem(0);
-        } else {
-            super.onBackPressed();
-        }
-    }
 
     private boolean shouldHandleWebViewBackPress() {
         WebViewFragment webView = getCurrentWebViewFragment();

--- a/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
@@ -703,8 +703,6 @@ public class ProfileDetailsActivity extends BaseAuthenticatedActivity
         }
     }
 
-
-
     @Override
     public void onLoaderReset(final Loader<ProfileDetails> loader) {
         // Intentionally left blank

--- a/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ProfileDetailsActivity.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 import android.provider.MediaStore;
 import androidx.annotation.NonNull;
 import androidx.loader.app.LoaderManager;
+import androidx.activity.OnBackPressedCallback;
 import androidx.loader.content.Loader;
 import androidx.appcompat.widget.AppCompatTextView;
 import androidx.appcompat.widget.Toolbar;
@@ -171,6 +172,18 @@ public class ProfileDetailsActivity extends BaseAuthenticatedActivity
         initializeDeleteAccountButton();
         initializeEditProfileButton();
         setupMenuActions();
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (firstNameRow.getVisibility() == View.VISIBLE) {
+                    cancelEditing();
+                } else {
+                    setEnabled(false);
+                    getOnBackPressedDispatcher().onBackPressed();
+                    setEnabled(true);
+                }
+            }
+        });
     }
 
     private void bindViews() {
@@ -690,15 +703,7 @@ public class ProfileDetailsActivity extends BaseAuthenticatedActivity
         }
     }
 
-    @Override
-    public void onBackPressed(){
-        //if backpress from edit mode then display the existing profile detail
-        if(firstNameRow.getVisibility() == View.VISIBLE) {
-            cancelEditing();
-        } else {
-            super.onBackPressed();
-        }
-    }
+
 
     @Override
     public void onLoaderReset(final Loader<ProfileDetails> loader) {

--- a/app/src/main/java/in/testpress/testpress/ui/ProfilePhotoActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/ProfilePhotoActivity.java
@@ -65,7 +65,7 @@ public class ProfilePhotoActivity extends TestpressFragmentActivity {
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         if(item.getItemId() == android.R.id.home) {
-            super.onBackPressed();
+            getOnBackPressedDispatcher().onBackPressed();
             return true;
         } else if(item.getItemId() == R.id.edit) {
             //handled on onActivityResult of ProfileDetailsActivity

--- a/app/src/main/java/in/testpress/testpress/ui/TermsAndConditionActivity.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/TermsAndConditionActivity.kt
@@ -141,8 +141,6 @@ class TermsAndConditionActivity : BaseToolBarActivity() {
         }
     }
 
-
-
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.logout_terms_and_conditions, menu)
         return super.onCreateOptionsMenu(menu)

--- a/app/src/main/java/in/testpress/testpress/ui/TermsAndConditionActivity.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/TermsAndConditionActivity.kt
@@ -20,6 +20,7 @@ import android.view.View
 import android.webkit.*
 import android.widget.*
 import androidx.appcompat.app.AlertDialog
+import androidx.activity.OnBackPressedCallback
 import java.io.IOException
 import javax.inject.Inject
 
@@ -57,6 +58,17 @@ class TermsAndConditionActivity : BaseToolBarActivity() {
         setContentView(R.layout.terms_and_condition_activity)
         bindViews()
         supportActionBar?.title = getString(R.string.terms_and_conditions)
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (webView.canGoBack()) {
+                    progressBar.visibility = View.VISIBLE
+                    webView.visibility = View.GONE
+                    webView.goBack()
+                } else {
+                    finishAffinity()
+                }
+            }
+        })
     }
 
     private fun bindViews() {
@@ -129,15 +141,7 @@ class TermsAndConditionActivity : BaseToolBarActivity() {
         }
     }
 
-    override fun onBackPressed() {
-        if (webView.canGoBack()){
-            progressBar.visibility = View.VISIBLE
-            webView.visibility = View.GONE
-            webView.goBack()
-        } else {
-            finishAffinity()
-        }
-    }
+
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.logout_terms_and_conditions, menu)

--- a/app/src/main/java/in/testpress/testpress/ui/TestpressFragmentActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/TestpressFragmentActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.activity.OnBackPressedCallback;
 import androidx.appcompat.widget.Toolbar;
 
 import android.view.MenuItem;
@@ -72,6 +73,22 @@ public class TestpressFragmentActivity extends AppCompatActivity {
 
         eventBus.register(busEventListener);
         eventBus.register(unauthorisedUserErrorBusListener);
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                try {
+                    if (isFromDeeplink()) {
+                        goToHome();
+                    } else {
+                        setEnabled(false);
+                        getOnBackPressedDispatcher().onBackPressed();
+                        setEnabled(true);
+                    }
+                } catch (IllegalStateException e) {
+                    supportFinishAfterTransition();
+                }
+            }
+        });
     }
 
     public Toolbar getActionBarToolbar() {
@@ -111,25 +128,14 @@ public class TestpressFragmentActivity extends AppCompatActivity {
             if (isFromDeeplink()) {
                 goToHome();
             } else {
-                onBackPressed();
+                getOnBackPressedDispatcher().onBackPressed();
             }
             return true;
         }
         return false;
     }
 
-    @Override
-    public void onBackPressed() {
-        try {
-            if (isFromDeeplink()) {
-                goToHome();
-            } else {
-                super.onBackPressed();
-            }
-        } catch (IllegalStateException e) {
-            supportFinishAfterTransition();
-        }
-    }
+
 
     @Override
     protected void onResume() {

--- a/app/src/main/java/in/testpress/testpress/ui/TestpressFragmentActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/TestpressFragmentActivity.java
@@ -82,10 +82,11 @@ public class TestpressFragmentActivity extends AppCompatActivity {
                     } else {
                         setEnabled(false);
                         getOnBackPressedDispatcher().onBackPressed();
-                        setEnabled(true);
                     }
                 } catch (IllegalStateException e) {
                     supportFinishAfterTransition();
+                } finally {
+                    setEnabled(true);
                 }
             }
         });
@@ -134,8 +135,6 @@ public class TestpressFragmentActivity extends AppCompatActivity {
         }
         return false;
     }
-
-
 
     @Override
     protected void onResume() {

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -13,7 +13,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
-import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AlertDialog;
@@ -21,7 +20,6 @@ import androidx.activity.OnBackPressedCallback;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import android.util.Log;
-import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -363,8 +361,6 @@ public class WebViewActivity extends BaseToolBarActivity {
         return File.createTempFile(imageFileName, ".jpg", storageDir);
     }
 
-
-
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
@@ -396,8 +392,6 @@ public class WebViewActivity extends BaseToolBarActivity {
 
         return super.onOptionsItemSelected(item);
     }
-
-
 
     public void logout() {
         new AlertDialog.Builder(this, R.style.AppCompatAlertDialogStyle)

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AlertDialog;
+import androidx.activity.OnBackPressedCallback;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import android.util.Log;
@@ -299,6 +300,19 @@ public class WebViewActivity extends BaseToolBarActivity {
                 return true;
             }
         });
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (getIntent().getBooleanExtra(ENABLE_BACK, false) && webView.canGoBack()) {
+                    reload = true;
+                    webView.goBack();
+                } else if (webView.canGoBack()) {
+                    webView.goBack();
+                } else {
+                    finish();
+                }
+            }
+        });
     }
 
     private Boolean isInstituteURL(String url){
@@ -349,26 +363,7 @@ public class WebViewActivity extends BaseToolBarActivity {
         return File.createTempFile(imageFileName, ".jpg", storageDir);
     }
 
-    @Override
-    public boolean onKeyDown(int keyCode, @NonNull KeyEvent event) {
 
-        if (event.getAction() == KeyEvent.ACTION_DOWN) {
-
-            switch (keyCode) {
-                case KeyEvent.KEYCODE_BACK:
-
-                    if (webView.canGoBack()) {
-                        webView.goBack();
-                    } else {
-                        finish();
-                    }
-
-                    return true;
-            }
-        }
-
-        return super.onKeyDown(keyCode, event);
-    }
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
@@ -402,15 +397,7 @@ public class WebViewActivity extends BaseToolBarActivity {
         return super.onOptionsItemSelected(item);
     }
 
-    @Override
-    public void onBackPressed() {
-        if (getIntent().getBooleanExtra(ENABLE_BACK, false) && webView.canGoBack()) {
-            reload = true;
-            webView.goBack();
-        } else {
-            super.onBackPressed();
-        }
-    }
+
 
     public void logout() {
         new AlertDialog.Builder(this, R.style.AppCompatAlertDialogStyle)


### PR DESCRIPTION
- The `onBackPressed()` and back button `onKeyDown()` handling methods are deprecated in newer Android versions
- Replaced deprecated back press interceptions with `OnBackPressedDispatcher` and `OnBackPressedCallback`
- Updated multiple activities including ProfileDetailsActivity, TermsAndConditionActivity, TestpressFragmentActivity, and WebViewActivity
- This change ensures compatibility with predictive back gestures in modern Android versions