### PR TITLE
build: Update compile and target SDK versions to 36

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -134,7 +134,7 @@ try {
 
 android {
 
-    compileSdkVersion 35
+    compileSdkVersion 36
     ndkVersion "25.1.8937393"
     namespace 'in.testpress.testpress'
 
@@ -174,7 +174,7 @@ android {
 
     defaultConfig {
         minSdkVersion 26
-        targetSdkVersion 35
+        targetSdkVersion 36
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         versionName json.version


### PR DESCRIPTION
Updated compileSdkVersion and targetSdkVersion in the app module from 35 to 36 to target the latest Android API level.