### PR TITLE
fix: Prevent build failure when social login keys are null

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -187,9 +187,11 @@ android {
         resValue "string", "testpress_site_subdomain", json.testpress_site_subdomain
         resValue "string", "version", json.version
         resValue "string", "share_message", json.share_message
-        resValue "string", "facebook_app_id", json.facebook_app_id
-        resValue "string", "fb_login_protocol_scheme", json.facebook_app_id
-        resValue "string", "server_client_id", json.server_client_id
+        def facebookAppId = json.facebook_app_id ?: ""
+        resValue "string", "facebook_app_id", facebookAppId
+        resValue "string", "fb_login_protocol_scheme", facebookAppId
+        def serverClientId = json.server_client_id ?: ""
+        resValue "string", "server_client_id", serverClientId
         resValue "color", "primary", json.primary_color
         resValue "color", "secondary", json.secondary_color
         resValue "color", "tertiary", json.tertiary_color


### PR DESCRIPTION
- Previously, older Android Gradle Plugin (AGP) versions allowed passing null values to resValue, generating either an empty resource or the literal string "null" without failing the build.
- Now, newer AGP versions (such as 8.5.1) enforce strict nullability via @NonNull annotations, causing the build to fail with a parameter validation error ("Parameter specified as non-null is null") if these configuration keys are missing or null.
- Fixed by defaulting the values to empty strings using the Groovy Elvis operator (?: "") before passing them to resValue, satisfying the non-null type constraint.