### PR TITLE
build: Upgrade Kotlin to 2.2.20 and Dagger to 2.60.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,6 +119,12 @@ dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 }
 
+configurations.all {
+    // Exclude legacy Kotlin android extensions to prevent duplicate class packaging conflicts 
+    // with the modern kotlin-parcelize-runtime library pulled in by newer dependencies.
+    exclude group: 'org.jetbrains.kotlin', module: 'kotlin-android-extensions-runtime'
+}
+
 def key_alias = "sample"
 def key_password = "sample"
 def store_file = "testpress_debug_keystore.jks"
@@ -148,7 +154,6 @@ android {
         viewBinding true
         compose true
     }
-
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ import groovy.json.JsonSlurper
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 ext {
     testpressSDK = '1.4.288'
@@ -18,8 +19,8 @@ dependencies {
     def fragment_version = "1.4.1"
 
     // Dependency Injection
-    implementation 'com.google.dagger:dagger:2.48'
-    kapt 'com.google.dagger:dagger-compiler:2.48'
+    implementation 'com.google.dagger:dagger:2.60.1'
+    kapt 'com.google.dagger:dagger-compiler:2.60.1'
     implementation "ru.tinkoff.scrollingpagerindicator:scrollingpagerindicator:1.1.0"
 
     implementation 'com.github.kevinsawicki:wishlist:0.9@aar'
@@ -148,9 +149,6 @@ android {
         compose true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion '1.5.11'
-    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
@@ -10,6 +10,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:8.5.1'
         classpath 'com.google.gms:google-services:4.3.14'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:compose-compiler-gradle-plugin:$kotlin_version"
 
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
@@ -17,6 +18,11 @@ buildscript {
 }
 
 allprojects {
+    configurations.all {
+        // Exclude legacy Kotlin android extensions to prevent duplicate class packaging conflicts 
+        // with the modern kotlin-parcelize-runtime library pulled in by newer dependencies.
+        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-android-extensions-runtime'
+    }
     repositories {
         maven {
             url 'https://github.com/friberry/mvn-repo/raw/master/'

--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,6 @@ buildscript {
 }
 
 allprojects {
-    configurations.all {
-        // Exclude legacy Kotlin android extensions to prevent duplicate class packaging conflicts 
-        // with the modern kotlin-parcelize-runtime library pulled in by newer dependencies.
-        exclude group: 'org.jetbrains.kotlin', module: 'kotlin-android-extensions-runtime'
-    }
     repositories {
         maven {
             url 'https://github.com/friberry/mvn-repo/raw/master/'


### PR DESCRIPTION
- Upgrade Kotlin version to 2.2.20 to align with the latest Testpress Android SDK updates.
- Set up the Kotlin 2.x Compose compiler Gradle plugin in the root build configuration and apply it in the app module.
- Remove the obsolete composeOptions.kotlinCompilerExtensionVersion config.
- Upgrade Dagger and its compiler to 2.60.1 to natively support parsing Kotlin 2.2.0 class metadata during Kapt annotation processing.
- Add a global configuration exclusion for kotlin-android-extensions-runtime to prevent duplicate class packaging conflicts.