### PR TITLE
build: Override R8 version to fix Kotlin metadata parsing errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
+        classpath 'com.android.tools:r8:8.11.32'
         classpath 'com.android.tools.build:gradle:8.9.1'
         classpath 'com.google.gms:google-services:4.3.14'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"


### PR DESCRIPTION
- The build encountered unexpected D8/R8 parsing exceptions when parsing Kotlin metadata for classes compiled with Kotlin 2.2.
- This occurred because the default R8 compiler version (8.9.32) bundled inside the Android Gradle Plugin (8.9.1) does not support newer Kotlin 2.2 metadata formats.
- Fixed by overriding the R8 compiler version to 8.11.32 in the root build.gradle 