### PR TITLE
fix: Captured camera images aren't attached in doubts activity WebView

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="in.testpress.testpress">
 
+    <queries>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+    </queries>
+
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,6 +52,16 @@
             android:name="preloaded_fonts"
             android:resource="@array/preloaded_fonts" />
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_provider_paths" />
+        </provider>
+
         <activity
             android:name=".ui.SplashScreenActivity"
             android:theme="@style/AppTheme"

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -274,6 +274,7 @@ public class WebViewActivity extends BaseToolBarActivity {
                                 getApplicationContext().getPackageName() + ".fileprovider",
                                 photoFile);
                         takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, mCapturedImageUri);
+                        takePictureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
                     } else {
                         takePictureIntent = null;
                     }
@@ -359,6 +360,9 @@ public class WebViewActivity extends BaseToolBarActivity {
         @SuppressLint("SimpleDateFormat") String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "img_" + timeStamp + "_";
         File storageDir = getExternalFilesDir(Environment.DIRECTORY_PICTURES);
+        if (storageDir == null) {
+            throw new IOException("External storage is unavailable");
+        }
         return File.createTempFile(imageFileName, ".jpg", storageDir);
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
+import androidx.core.content.FileProvider;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
@@ -65,7 +66,7 @@ public class WebViewActivity extends BaseToolBarActivity {
     private ProgressBar pb_loading;
     private SwipeRefreshLayout swipeContainer;
     WebView webView;
-    private String mCapturedMessage;
+    private Uri mCapturedImageUri;
     private ValueCallback<Uri> mUploadMessage;
     private ValueCallback<Uri[]> mUploadMessages;
     private String url;
@@ -88,21 +89,19 @@ public class WebViewActivity extends BaseToolBarActivity {
                     if (null == mUploadMessages) {
                         return;
                     }
-                    if (intent == null) {
+                    if (intent == null || intent.getData() == null) {
                         //Capture Photo if no image available
-                        if (mCapturedMessage != null) {
-                            results = new Uri[]{Uri.parse(mCapturedMessage)};
+                        if (mCapturedImageUri != null) {
+                            results = new Uri[]{mCapturedImageUri};
                         }
                     } else {
-                        String dataString = intent.getDataString();
-                        if (dataString != null) {
-                            results = new Uri[]{Uri.parse(dataString)};
-                        }
+                        results = new Uri[]{intent.getData()};
                     }
                 }
             }
             mUploadMessages.onReceiveValue(results);
             mUploadMessages = null;
+            mCapturedImageUri = null;
         } else {
 
             if (requestCode == FILE_CHOOSER_RESULT_CODE) {
@@ -266,13 +265,15 @@ public class WebViewActivity extends BaseToolBarActivity {
 
                     try {
                         photoFile = createImageFile();
-                        takePictureIntent.putExtra("PhotoPath", mCapturedMessage);
                     } catch (IOException ex) {
                         Log.e(TAG, "Image file creation failed", ex);
                     }
                     if (photoFile != null) {
-                        mCapturedMessage = "file:" + photoFile.getAbsolutePath();
-                        takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, Uri.fromFile(photoFile));
+                        mCapturedImageUri = FileProvider.getUriForFile(
+                                WebViewActivity.this,
+                                getApplicationContext().getPackageName() + ".fileprovider",
+                                photoFile);
+                        takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, mCapturedImageUri);
                     } else {
                         takePictureIntent = null;
                     }
@@ -357,7 +358,7 @@ public class WebViewActivity extends BaseToolBarActivity {
 
         @SuppressLint("SimpleDateFormat") String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
         String imageFileName = "img_" + timeStamp + "_";
-        File storageDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+        File storageDir = getExternalFilesDir(Environment.DIRECTORY_PICTURES);
         return File.createTempFile(imageFileName, ".jpg", storageDir);
     }
 

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-files-path name="camera_images" path="Pictures/" />
+    <external-path name="external_pictures" path="Pictures/" />
+    <cache-path name="cache_images" path="." />
+</paths>

--- a/app/src/main/res/xml/file_provider_paths.xml
+++ b/app/src/main/res/xml/file_provider_paths.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
     <external-files-path name="camera_images" path="Pictures/" />
-    <external-path name="external_pictures" path="Pictures/" />
     <cache-path name="cache_images" path="." />
 </paths>


### PR DESCRIPTION
#### What is the purpose of this change?

- Fixes an issue where images captured from the WebView attachment flow were not attached to the helpdesk (doubts) form after taking a photo.
- The failure occurred when users selected the camera option from the attachment picker, preventing captured images from being uploaded and submitted due to broken (Android 8) `Uri.fromFile()` usage.
- Restores the expected attachment flow so captured photos are returned to the WebView, uploaded successfully, and previewed in the form before submission.
- Adds the required support for securely sharing captured image files between the camera app and the Android app, improving compatibility across supported Android versions.

#### Basecamp todo link (if applicable)
[TODOLINK](https://3.basecamp.com/4160028/buckets/47909775/card_tables/cards/10149450545)