### PR TITLE
build: Update Compose BOM to 2026.06.01

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     implementation 'com.github.alexto9090:PRDownloader:1.0'
     implementation 'com.salesforce.marketingcloud:marketingcloudsdk:8.0.7'
 
-    def composeBom = platform('androidx.compose:compose-bom:2023.09.01')
+    def composeBom = platform('androidx.compose:compose-bom:2026.06.01')
     implementation(composeBom)
     androidTestImplementation(composeBom)
 


### PR DESCRIPTION
- Update the `androidx.compose:compose-bom` dependency from `2023.09.01` to `2026.06.01`
- This brings in the latest Compose library versions for new features and bug fixes