### PR TITLE
fix: Safeguard Google Sign-In initialization

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -238,24 +238,27 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
         passwordText.setTypeface(Typeface.DEFAULT);
         passwordText.setTransformationMethod(new PasswordTransformationMethod());
         callbackManager = CallbackManager.Factory.create();
-        GoogleSignInOptions googleSignInOptions = new GoogleSignInOptions.Builder(
-                GoogleSignInOptions.DEFAULT_SIGN_IN)
-                .requestEmail()
-                .requestIdToken(getString(R.string.server_client_id))
-                .build();
-        googleApiClient = new GoogleApiClient.Builder(this)
-                .enableAutoManage(this, new GoogleApiClient.OnConnectionFailedListener() {
-                    @Override
-                    public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
-                        if (connectionResult.getErrorMessage() != null) {
-                            showAlert(connectionResult.getErrorMessage());
-                        } else {
-                            showAlert(connectionResult.toString());
+        String serverClientId = getString(R.string.server_client_id);
+        if (serverClientId != null && !serverClientId.trim().isEmpty()) {
+            GoogleSignInOptions googleSignInOptions = new GoogleSignInOptions.Builder(
+                    GoogleSignInOptions.DEFAULT_SIGN_IN)
+                    .requestEmail()
+                    .requestIdToken(serverClientId)
+                    .build();
+            googleApiClient = new GoogleApiClient.Builder(this)
+                    .enableAutoManage(this, new GoogleApiClient.OnConnectionFailedListener() {
+                        @Override
+                        public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
+                            if (connectionResult.getErrorMessage() != null) {
+                                showAlert(connectionResult.getErrorMessage());
+                            } else {
+                                showAlert(connectionResult.toString());
+                            }
                         }
-                    }
-                })
-                .addApi(Auth.GOOGLE_SIGN_IN_API, googleSignInOptions)
-                .build();
+                    })
+                    .addApi(Auth.GOOGLE_SIGN_IN_API, googleSignInOptions)
+                    .build();
+        }
         orLabel.setTypeface(TestpressSdk.getRubikMediumFont(this));
         DaoSession daoSession = ((TestpressApplication) getApplicationContext()).getDaoSession();
         instituteSettingsDao = daoSession.getInstituteSettingsDao();
@@ -686,8 +689,10 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
     }
 
     private void googleSignIn() {
-        Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(googleApiClient);
-        startActivityForResult(signInIntent, REQUEST_CODE_GOOGLE_SIGN_IN);
+        if (googleApiClient != null) {
+            Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(googleApiClient);
+            startActivityForResult(signInIntent, REQUEST_CODE_GOOGLE_SIGN_IN);
+        }
     }
 
     private void initWebView() {

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -692,6 +692,8 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
         if (googleApiClient != null) {
             Intent signInIntent = Auth.GoogleSignInApi.getSignInIntent(googleApiClient);
             startActivityForResult(signInIntent, REQUEST_CODE_GOOGLE_SIGN_IN);
+        } else {
+            showAlert(getString(R.string.google_signin_not_configured));
         }
     }
 

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
@@ -114,11 +114,15 @@ class LoginActivityV2: ActionBarAccountAuthenticatorActivity(), LoginNavigationI
     }
 
     private fun initializeGoogleSignIn() {
+        val serverClientId = getString(R.string.server_client_id)
+        if (serverClientId.isNullOrBlank()) {
+            return
+        }
         val googleSignInOptions = GoogleSignInOptions.Builder(
             GoogleSignInOptions.DEFAULT_SIGN_IN
         )
             .requestEmail()
-            .requestIdToken(getString(R.string.server_client_id))
+            .requestIdToken(serverClientId)
             .build()
         googleApiClient = GoogleSignIn.getClient(this, googleSignInOptions)
     }
@@ -132,7 +136,9 @@ class LoginActivityV2: ActionBarAccountAuthenticatorActivity(), LoginNavigationI
     }
 
     override fun signInWithGoogle() {
-        handleGoogleSignIn.launch(googleApiClient.signInIntent)
+        if (::googleApiClient.isInitialized) {
+            handleGoogleSignIn.launch(googleApiClient.signInIntent)
+        }
     }
 
     override fun goToOTPVerification(phoneNumber: String, countryCode: String) {

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivityV2.kt
@@ -115,7 +115,7 @@ class LoginActivityV2: ActionBarAccountAuthenticatorActivity(), LoginNavigationI
 
     private fun initializeGoogleSignIn() {
         val serverClientId = getString(R.string.server_client_id)
-        if (serverClientId.isNullOrBlank()) {
+        if (serverClientId.isBlank()) {
             return
         }
         val googleSignInOptions = GoogleSignInOptions.Builder(
@@ -138,6 +138,8 @@ class LoginActivityV2: ActionBarAccountAuthenticatorActivity(), LoginNavigationI
     override fun signInWithGoogle() {
         if (::googleApiClient.isInitialized) {
             handleGoogleSignIn.launch(googleApiClient.signInIntent)
+        } else {
+            UIUtils.showAlert(this, getString(R.string.google_signin_not_configured))
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="login_with_facebook">Login with Facebook</string>
     <string name="login_with_google">Login with Google</string>
     <string name="google_sign_in_wrong_hash">Google sign in error, please contact the administrator to check key hashes.</string>
+    <string name="google_signin_not_configured">Google Sign-In is not configured for this application.</string>
 
     <string name="logout">Log Out</string>
     <string name="logout_confirm_message">Are you sure you want to log out?</string>


### PR DESCRIPTION
- The application crashed on launching the login activity due to a java.lang.IllegalArgumentException: "Given String is empty or null"
- This occurred because the Google Play Services auth SDK was upgraded, which now strictly asserts that the client ID passed to requestIdToken() must not be empty or null, crashing when R.string.server_client_id is empty
- Fixed by checking if the client ID is blank before initializing the Google Sign-In options, and verifying the Google API client is initialized before launching the sign-in intent