### PR TITLE
fix: Webview camera upload opens file picker instead of launching camera directly

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -278,24 +278,30 @@ public class WebViewActivity extends BaseToolBarActivity {
                     } else {
                         takePictureIntent = null;
                     }
-                }
-
-                Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
-                contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
-                contentSelectionIntent.setType("*/*");
-                Intent[] intentArray;
-
-                if (takePictureIntent != null) {
-                    intentArray = new Intent[]{takePictureIntent};
                 } else {
-                    intentArray = new Intent[0];
+                    takePictureIntent = null;
                 }
 
-                Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
-                chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
-                chooserIntent.putExtra(Intent.EXTRA_TITLE, "Image Chooser");
-                chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentArray);
-                startActivityForResult(chooserIntent, FILE_CHOOSER_RESULT_CODE);
+                if (fileChooserParams.isCaptureEnabled() && takePictureIntent != null) {
+                    startActivityForResult(takePictureIntent, FILE_CHOOSER_RESULT_CODE);
+                } else {
+                    Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
+                    contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
+                    contentSelectionIntent.setType("*/*");
+                    Intent[] intentArray;
+
+                    if (takePictureIntent != null) {
+                        intentArray = new Intent[]{takePictureIntent};
+                    } else {
+                        intentArray = new Intent[0];
+                    }
+
+                    Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
+                    chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
+                    chooserIntent.putExtra(Intent.EXTRA_TITLE, "Image Chooser");
+                    chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentArray);
+                    startActivityForResult(chooserIntent, FILE_CHOOSER_RESULT_CODE);
+                }
 
                 return true;
             }


### PR DESCRIPTION
#### What is the purpose of this change?

- HTML file inputs requesting direct camera capture opened a generic file picker dialog instead of launching the camera directly.
- Occurred because the file chooser handler unconditionally routed intent requests through an ACTION_CHOOSER prompt regardless of the capture attribute setting.
- Degraded user experience by adding unnecessary navigation steps when web forms specifically requested immediate camera capture.
- The webview now evaluates the file chooser capture flag and launches the camera interface directly when requested by the web page.

#### Basecamp todo link (if applicable)
[TODOLINK](https://3.basecamp.com/4160028/buckets/48341145/card_tables/cards/10156273402)

