### PR TITLE
fix: Launch camera and file chooser directly in WebView to bypass MDM-managed devices

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,6 +117,12 @@ dependencies {
     implementation "com.google.android.material:material:1.8.0"
     implementation "androidx.exifinterface:exifinterface:1.3.6"
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
+
+    def camerax_version = "1.3.1"
+    implementation "androidx.camera:camera-core:${camerax_version}"
+    implementation "androidx.camera:camera-camera2:${camerax_version}"
+    implementation "androidx.camera:camera-lifecycle:${camerax_version}"
+    implementation "androidx.camera:camera-view:${camerax_version}"
 }
 
 configurations.all {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -158,10 +158,9 @@
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="Verify" />
         <activity
-            android:name=".ui.DoubtsActivity"
+            android:name=".ui.SSOWebViewRedirectActivity"
             android:theme="@style/AppTheme"
-            android:configChanges="orientation|keyboardHidden|screenSize"
-            android:label="Doubts" />
+            android:configChanges="orientation|keyboardHidden|screenSize" />
         <activity
             android:name=".ui.QotdActivity"
             android:theme="@style/AppTheme"
@@ -242,6 +241,11 @@
             android:theme="@style/TestpressWebViewTheme"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="Web View" />
+            
+        <activity android:name=".ui.InAppCameraActivity"
+            android:theme="@style/AppTheme"
+            android:configChanges="orientation|keyboardHidden|screenSize"
+            android:label="Camera"/>
 
         <activity android:name=".ui.TermsAndConditionActivity"
             android:theme="@style/AppTheme"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
 
     <uses-feature android:name="android.hardware.telephony" android:required="false" />
 <!--    <uses-sdk tools:overrideLibrary="us.zoom.androidlib,us.zoom.videomeetings"/>-->

--- a/app/src/main/java/in/testpress/testpress/AppComponent.java
+++ b/app/src/main/java/in/testpress/testpress/AppComponent.java
@@ -14,7 +14,7 @@ import in.testpress.testpress.ui.BaseAuthenticatedActivity;
 import in.testpress.testpress.ui.DeviceNotAllowedActivity;
 import in.testpress.testpress.ui.DocumentsListActivity;
 import in.testpress.testpress.ui.DocumentsListFragment;
-import in.testpress.testpress.ui.DoubtsActivity;
+import in.testpress.testpress.ui.SSOWebViewRedirectActivity;
 import in.testpress.testpress.ui.QotdActivity;
 import in.testpress.testpress.ui.DrupalRssListActivity;
 import in.testpress.testpress.ui.DrupalRssListFragment;
@@ -63,7 +63,7 @@ public interface AppComponent {
     void inject(AccountActivateActivity accountActivateActivity);
     void inject(WebViewActivity webViewActivity);
     void inject(DashboardFragment dashboardFragment);
-    void inject(DoubtsActivity doubtsActivity);
+    void inject(SSOWebViewRedirectActivity redirectActivity);
     void inject(QotdActivity qotdActivity);
     void inject(LoginActivityV2 loginActivityV2);
     void inject(UsernameAuthentication usernameAuthentication);

--- a/app/src/main/java/in/testpress/testpress/ui/InAppCameraActivity.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/InAppCameraActivity.kt
@@ -1,0 +1,142 @@
+package `in`.testpress.testpress.ui
+
+import android.Manifest
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.os.Environment
+import android.util.Log
+import android.widget.ImageButton
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageCapture
+import androidx.camera.core.ImageCaptureException
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import `in`.testpress.testpress.R
+
+class InAppCameraActivity : AppCompatActivity() {
+
+    private var imageCapture: ImageCapture? = null
+    private lateinit var cameraExecutor: ExecutorService
+    private lateinit var viewFinder: PreviewView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_in_app_camera)
+
+        viewFinder = findViewById(R.id.viewFinder)
+
+        if (allPermissionsGranted()) {
+            startCamera()
+        } else {
+            ActivityCompat.requestPermissions(
+                this, REQUIRED_PERMISSIONS, REQUEST_CODE_PERMISSIONS
+            )
+        }
+
+        findViewById<ImageButton>(R.id.image_capture_button).setOnClickListener { takePhoto() }
+        findViewById<ImageButton>(R.id.close_button).setOnClickListener { finish() }
+
+        cameraExecutor = Executors.newSingleThreadExecutor()
+    }
+
+    private fun takePhoto() {
+        val imageCapture = imageCapture ?: return
+
+        val storageDir = getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+        val timeStamp = SimpleDateFormat(FILENAME_FORMAT, Locale.US).format(Date())
+        val photoFile = File.createTempFile("img_${timeStamp}_", ".jpg", storageDir)
+
+        val outputOptions = ImageCapture.OutputFileOptions.Builder(photoFile).build()
+
+        imageCapture.takePicture(
+            outputOptions,
+            ContextCompat.getMainExecutor(this),
+            object : ImageCapture.OnImageSavedCallback {
+                override fun onError(exc: ImageCaptureException) {
+                    Log.e(TAG, "Photo capture failed: ${exc.message}", exc)
+                    finish()
+                }
+
+                override fun onImageSaved(output: ImageCapture.OutputFileResults) {
+                    val savedUri = output.savedUri ?: android.net.Uri.fromFile(photoFile)
+                    val intent = Intent().apply {
+                        data = savedUri
+                    }
+                    setResult(Activity.RESULT_OK, intent)
+                    finish()
+                }
+            }
+        )
+    }
+
+    private fun startCamera() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
+
+        cameraProviderFuture.addListener({
+            val cameraProvider: ProcessCameraProvider = cameraProviderFuture.get()
+
+            val preview = Preview.Builder()
+                .build()
+                .also {
+                    it.setSurfaceProvider(viewFinder.surfaceProvider)
+                }
+
+            imageCapture = ImageCapture.Builder()
+                .build()
+
+            val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
+
+            try {
+                cameraProvider.unbindAll()
+                cameraProvider.bindToLifecycle(
+                    this, cameraSelector, preview, imageCapture
+                )
+            } catch (exc: Exception) {
+                Log.e(TAG, "Use case binding failed", exc)
+            }
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int, permissions: Array<String>, grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_CODE_PERMISSIONS) {
+            if (allPermissionsGranted()) {
+                startCamera()
+            } else {
+                Toast.makeText(this, "Camera permissions not granted by the user.", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+        }
+    }
+
+    private fun allPermissionsGranted() = REQUIRED_PERMISSIONS.all {
+        ContextCompat.checkSelfPermission(baseContext, it) == PackageManager.PERMISSION_GRANTED
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        cameraExecutor.shutdown()
+    }
+
+    companion object {
+        private const val TAG = "InAppCameraActivity"
+        private const val FILENAME_FORMAT = "yyyyMMdd_HHmmss"
+        private const val REQUEST_CODE_PERMISSIONS = 10
+        private val REQUIRED_PERMISSIONS = arrayOf(Manifest.permission.CAMERA)
+    }
+}

--- a/app/src/main/java/in/testpress/testpress/ui/InAppCameraActivity.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/InAppCameraActivity.kt
@@ -18,6 +18,7 @@ import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.PreviewView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -29,8 +30,8 @@ import `in`.testpress.testpress.R
 class InAppCameraActivity : AppCompatActivity() {
 
     private var imageCapture: ImageCapture? = null
-    private lateinit var cameraExecutor: ExecutorService
     private lateinit var viewFinder: PreviewView
+    private var isCapturing = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -46,18 +47,29 @@ class InAppCameraActivity : AppCompatActivity() {
             )
         }
 
-        findViewById<ImageButton>(R.id.image_capture_button).setOnClickListener { takePhoto() }
+        findViewById<ImageButton>(R.id.image_capture_button).setOnClickListener { 
+            if (!isCapturing) {
+                isCapturing = true
+                takePhoto() 
+            }
+        }
         findViewById<ImageButton>(R.id.close_button).setOnClickListener { finish() }
-
-        cameraExecutor = Executors.newSingleThreadExecutor()
     }
 
     private fun takePhoto() {
         val imageCapture = imageCapture ?: return
 
-        val storageDir = getExternalFilesDir(Environment.DIRECTORY_PICTURES)
-        val timeStamp = SimpleDateFormat(FILENAME_FORMAT, Locale.US).format(Date())
-        val photoFile = File.createTempFile("img_${timeStamp}_", ".jpg", storageDir)
+        val photoFile: File
+        try {
+            val storageDir = getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+            val timeStamp = SimpleDateFormat(FILENAME_FORMAT, Locale.US).format(Date())
+            photoFile = File.createTempFile("img_${timeStamp}_", ".jpg", storageDir)
+        } catch (ex: Exception) {
+            Log.e(TAG, "Image file creation failed", ex)
+            Toast.makeText(this, R.string.image_creation_failed, Toast.LENGTH_SHORT).show()
+            finish()
+            return
+        }
 
         val outputOptions = ImageCapture.OutputFileOptions.Builder(photoFile).build()
 
@@ -71,10 +83,15 @@ class InAppCameraActivity : AppCompatActivity() {
                 }
 
                 override fun onImageSaved(output: ImageCapture.OutputFileResults) {
-                    val savedUri = output.savedUri ?: android.net.Uri.fromFile(photoFile)
+                    val savedUri = output.savedUri ?: FileProvider.getUriForFile(
+                        this@InAppCameraActivity,
+                        applicationContext.packageName + ".fileprovider",
+                        photoFile
+                    )
                     val intent = Intent().apply {
                         data = savedUri
                     }
+                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
                     setResult(Activity.RESULT_OK, intent)
                     finish()
                 }
@@ -118,7 +135,7 @@ class InAppCameraActivity : AppCompatActivity() {
             if (allPermissionsGranted()) {
                 startCamera()
             } else {
-                Toast.makeText(this, "Camera permissions not granted by the user.", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, R.string.camera_permission_denied, Toast.LENGTH_SHORT).show()
                 finish()
             }
         }
@@ -130,7 +147,6 @@ class InAppCameraActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        cameraExecutor.shutdown()
     }
 
     companion object {

--- a/app/src/main/java/in/testpress/testpress/ui/SSOWebViewRedirectActivity.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/SSOWebViewRedirectActivity.kt
@@ -75,11 +75,13 @@ class SSOWebViewRedirectActivity: TestpressFragmentActivity(), EmptyViewListener
     private fun openTicketsInWebview(ssoLink: SsoUrl?) {
         val webviewIntent = Intent(this@SSOWebViewRedirectActivity, WebViewActivity::class.java)
         webviewIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP;
-        val title = intent.getStringExtra("title") ?: "Doubts"
-        val nextPath = intent.getStringExtra("nextPath") ?: "/tickets/mobile/"
+        val title = intent.getStringExtra(EXTRA_TITLE) ?: "Doubts"
+        val nextPath = intent.getStringExtra(EXTRA_NEXT_PATH) ?: "/tickets/mobile/"
+        val allowExternal = intent.getBooleanExtra(EXTRA_ALLOW_EXTERNAL, false)
         webviewIntent.putExtra(WebViewActivity.ACTIVITY_TITLE, title)
         webviewIntent.putExtra(WebViewActivity.ENABLE_BACK, true)
         webviewIntent.putExtra(WebViewActivity.SHOW_LOADING, false)
+        webviewIntent.putExtra(WebViewActivity.ALLOW_EXTERNAL_LINK, allowExternal)
         webviewIntent.putExtra(
             WebViewActivity.URL_TO_OPEN,
             BuildConfig.WHITE_LABELED_HOST_URL + ssoLink?.ssoUrl + "&next=" + nextPath
@@ -97,5 +99,11 @@ class SSOWebViewRedirectActivity: TestpressFragmentActivity(), EmptyViewListener
 
     override fun onRetryClick() {
         fetchSsoLink()
+    }
+
+    companion object {
+        const val EXTRA_TITLE = "title"
+        const val EXTRA_NEXT_PATH = "nextPath"
+        const val EXTRA_ALLOW_EXTERNAL = "allowExternal"
     }
 }

--- a/app/src/main/java/in/testpress/testpress/ui/SSOWebViewRedirectActivity.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/SSOWebViewRedirectActivity.kt
@@ -16,7 +16,7 @@ import android.view.View
 import java.io.IOException
 import javax.inject.Inject
 
-class DoubtsActivity: TestpressFragmentActivity(), EmptyViewListener {
+class SSOWebViewRedirectActivity: TestpressFragmentActivity(), EmptyViewListener {
     @Inject
     lateinit var serviceProvider: TestpressServiceProvider
     lateinit var emptyViewFragment: EmptyViewFragment
@@ -36,7 +36,7 @@ class DoubtsActivity: TestpressFragmentActivity(), EmptyViewListener {
         object : SafeAsyncTask<SsoUrl?>() {
             @Throws(Exception::class)
             override fun call(): SsoUrl {
-                return serviceProvider.getService(this@DoubtsActivity).getSsoUrl()
+                return serviceProvider.getService(this@SSOWebViewRedirectActivity).getSsoUrl()
             }
 
             override fun onException(exception: java.lang.Exception?) {
@@ -73,16 +73,18 @@ class DoubtsActivity: TestpressFragmentActivity(), EmptyViewListener {
     }
 
     private fun openTicketsInWebview(ssoLink: SsoUrl?) {
-        val intent = Intent(this@DoubtsActivity, WebViewActivity::class.java)
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP;
-        intent.putExtra(WebViewActivity.ACTIVITY_TITLE, "Doubts")
-        intent.putExtra(WebViewActivity.ENABLE_BACK, true)
-        intent.putExtra(WebViewActivity.SHOW_LOADING, false)
-        intent.putExtra(
+        val webviewIntent = Intent(this@SSOWebViewRedirectActivity, WebViewActivity::class.java)
+        webviewIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP;
+        val title = intent.getStringExtra("title") ?: "Doubts"
+        val nextPath = intent.getStringExtra("nextPath") ?: "/tickets/mobile/"
+        webviewIntent.putExtra(WebViewActivity.ACTIVITY_TITLE, title)
+        webviewIntent.putExtra(WebViewActivity.ENABLE_BACK, true)
+        webviewIntent.putExtra(WebViewActivity.SHOW_LOADING, false)
+        webviewIntent.putExtra(
             WebViewActivity.URL_TO_OPEN,
-            BuildConfig.BASE_URL + ssoLink?.ssoUrl + "&next=/tickets/mobile/"
+            BuildConfig.WHITE_LABELED_HOST_URL + ssoLink?.ssoUrl + "&next=" + nextPath
         )
-        startActivity(intent)
+        startActivity(webviewIntent)
         finish()
     }
 

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -218,7 +218,7 @@ public class WebViewActivity extends BaseToolBarActivity {
                 Intent i = new Intent(Intent.ACTION_GET_CONTENT);
                 i.addCategory(Intent.CATEGORY_OPENABLE);
                 i.setType("*/*");
-                WebViewActivity.this.startActivityForResult(Intent.createChooser(i, "File Chooser"), FILE_CHOOSER_RESULT_CODE);
+                WebViewActivity.this.startActivityForResult(i, FILE_CHOOSER_RESULT_CODE);
             }
 
             // For Android 3.0+, above method not supported in some android 3+ versions, in such case we use this
@@ -228,9 +228,7 @@ public class WebViewActivity extends BaseToolBarActivity {
                 Intent i = new Intent(Intent.ACTION_GET_CONTENT);
                 i.addCategory(Intent.CATEGORY_OPENABLE);
                 i.setType("*/*");
-                WebViewActivity.this.startActivityForResult(
-                        Intent.createChooser(i, "File Browser"),
-                        FILE_CHOOSER_RESULT_CODE);
+                WebViewActivity.this.startActivityForResult(i, FILE_CHOOSER_RESULT_CODE);
             }
 
             //For Android 4.1+
@@ -240,7 +238,7 @@ public class WebViewActivity extends BaseToolBarActivity {
                 Intent i = new Intent(Intent.ACTION_GET_CONTENT);
                 i.addCategory(Intent.CATEGORY_OPENABLE);
                 i.setType("*/*");
-                WebViewActivity.this.startActivityForResult(Intent.createChooser(i, "File Chooser"), WebViewActivity.FILE_CHOOSER_RESULT_CODE);
+                WebViewActivity.this.startActivityForResult(i, WebViewActivity.FILE_CHOOSER_RESULT_CODE);
             }
 
             @Override
@@ -258,49 +256,15 @@ public class WebViewActivity extends BaseToolBarActivity {
                 }
 
                 mUploadMessages = filePathCallback;
-                Intent takePictureIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
-                if (takePictureIntent.resolveActivity(WebViewActivity.this.getPackageManager()) != null) {
 
-                    File photoFile = null;
-
-                    try {
-                        photoFile = createImageFile();
-                    } catch (IOException ex) {
-                        Log.e(TAG, "Image file creation failed", ex);
-                    }
-                    if (photoFile != null) {
-                        mCapturedImageUri = FileProvider.getUriForFile(
-                                WebViewActivity.this,
-                                getApplicationContext().getPackageName() + ".fileprovider",
-                                photoFile);
-                        takePictureIntent.putExtra(MediaStore.EXTRA_OUTPUT, mCapturedImageUri);
-                        takePictureIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                    } else {
-                        takePictureIntent = null;
-                    }
-                } else {
-                    takePictureIntent = null;
-                }
-
-                if (fileChooserParams.isCaptureEnabled() && takePictureIntent != null) {
+                if (fileChooserParams.isCaptureEnabled()) {
+                    Intent takePictureIntent = new Intent(WebViewActivity.this, InAppCameraActivity.class);
                     startActivityForResult(takePictureIntent, FILE_CHOOSER_RESULT_CODE);
                 } else {
                     Intent contentSelectionIntent = new Intent(Intent.ACTION_GET_CONTENT);
                     contentSelectionIntent.addCategory(Intent.CATEGORY_OPENABLE);
                     contentSelectionIntent.setType("*/*");
-                    Intent[] intentArray;
-
-                    if (takePictureIntent != null) {
-                        intentArray = new Intent[]{takePictureIntent};
-                    } else {
-                        intentArray = new Intent[0];
-                    }
-
-                    Intent chooserIntent = new Intent(Intent.ACTION_CHOOSER);
-                    chooserIntent.putExtra(Intent.EXTRA_INTENT, contentSelectionIntent);
-                    chooserIntent.putExtra(Intent.EXTRA_TITLE, "Image Chooser");
-                    chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, intentArray);
-                    startActivityForResult(chooserIntent, FILE_CHOOSER_RESULT_CODE);
+                    startActivityForResult(contentSelectionIntent, FILE_CHOOSER_RESULT_CODE);
                 }
 
                 return true;

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -5,15 +5,12 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
-import androidx.core.content.FileProvider;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Environment;
-import android.provider.MediaStore;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AlertDialog;
@@ -86,22 +83,13 @@ public class WebViewActivity extends BaseToolBarActivity {
             if (resultCode == Activity.RESULT_OK) {
                 if (requestCode == FILE_CHOOSER_RESULT_CODE) {
 
-                    if (null == mUploadMessages) {
-                        return;
-                    }
-                    if (intent == null || intent.getData() == null) {
-                        //Capture Photo if no image available
-                        if (mCapturedImageUri != null) {
-                            results = new Uri[]{mCapturedImageUri};
-                        }
-                    } else {
+                    if (intent != null && intent.getData() != null) {
                         results = new Uri[]{intent.getData()};
                     }
                 }
             }
             mUploadMessages.onReceiveValue(results);
             mUploadMessages = null;
-            mCapturedImageUri = null;
         } else {
 
             if (requestCode == FILE_CHOOSER_RESULT_CODE) {
@@ -324,17 +312,7 @@ public class WebViewActivity extends BaseToolBarActivity {
         this.url = url;
     }
 
-    // Create an image file
-    private File createImageFile() throws IOException {
 
-        @SuppressLint("SimpleDateFormat") String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-        String imageFileName = "img_" + timeStamp + "_";
-        File storageDir = getExternalFilesDir(Environment.DIRECTORY_PICTURES);
-        if (storageDir == null) {
-            throw new IOException("External storage is unavailable");
-        }
-        return File.createTempFile(imageFileName, ".jpg", storageDir);
-    }
 
     @Override
     public void onConfigurationChanged(Configuration newConfig) {

--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -24,7 +24,7 @@ import in.testpress.testpress.core.Constants;
 import in.testpress.testpress.models.DaoSession;
 import in.testpress.testpress.models.InstituteSettings;
 import in.testpress.testpress.models.InstituteSettingsDao;
-import in.testpress.testpress.ui.DoubtsActivity;
+import in.testpress.testpress.ui.SSOWebViewRedirectActivity;
 import in.testpress.testpress.ui.MainActivity;
 import in.testpress.testpress.ui.PostsListActivity;
 import in.testpress.testpress.ui.ProfileDetailsActivity;
@@ -88,7 +88,9 @@ public class HandleMainMenu {
             activity.startActivity(intent);
         });
         menuActions.put(R.id.doubts, () -> {
-            Intent intent = new Intent(activity, DoubtsActivity.class);
+            Intent intent = new Intent(activity, SSOWebViewRedirectActivity.class);
+            intent.putExtra("title", "Doubts");
+            intent.putExtra("nextPath", "/tickets/mobile/");
             activity.startActivity(intent);
         });
         menuActions.put(R.id.offline_exam_list, this::launchOfflineExamListActivity);
@@ -226,17 +228,10 @@ public class HandleMainMenu {
     }
 
     private void launchDiscussionActivity(String title) {
-        activity.startActivity(
-                WebViewWithSSOActivity.Companion.createIntent(
-                        activity,
-                        title,
-                        WHITE_LABELED_HOST_URL + "/discussions/new",
-                        true,
-                        false,
-                        true,
-                        WebViewWithSSOActivity.class
-                )
-        );
+        Intent intent = new Intent(activity, SSOWebViewRedirectActivity.class);
+        intent.putExtra("title", title);
+        intent.putExtra("nextPath", "/discussions/new");
+        activity.startActivity(intent);
     }
 
     private void launchOfflineExamListActivity() {

--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -89,8 +89,8 @@ public class HandleMainMenu {
         });
         menuActions.put(R.id.doubts, () -> {
             Intent intent = new Intent(activity, SSOWebViewRedirectActivity.class);
-            intent.putExtra("title", "Doubts");
-            intent.putExtra("nextPath", "/tickets/mobile/");
+            intent.putExtra(SSOWebViewRedirectActivity.EXTRA_TITLE, "Doubts");
+            intent.putExtra(SSOWebViewRedirectActivity.EXTRA_NEXT_PATH, "/tickets/mobile/");
             activity.startActivity(intent);
         });
         menuActions.put(R.id.offline_exam_list, this::launchOfflineExamListActivity);
@@ -229,8 +229,9 @@ public class HandleMainMenu {
 
     private void launchDiscussionActivity(String title) {
         Intent intent = new Intent(activity, SSOWebViewRedirectActivity.class);
-        intent.putExtra("title", title);
-        intent.putExtra("nextPath", "/discussions/new");
+        intent.putExtra(SSOWebViewRedirectActivity.EXTRA_TITLE, title);
+        intent.putExtra(SSOWebViewRedirectActivity.EXTRA_NEXT_PATH, "/discussions/new");
+        intent.putExtra(SSOWebViewRedirectActivity.EXTRA_ALLOW_EXTERNAL, true);
         activity.startActivity(intent);
     }
 

--- a/app/src/main/res/drawable/ic_shutter.xml
+++ b/app/src/main/res/drawable/ic_shutter.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="72"
+    android:viewportHeight="72">
+    <path
+        android:pathData="M36,36m-30,0a30,30 0,1 1,60 0a30,30 0,1 1,-60 0"
+        android:fillColor="#FFFFFF"/>
+    <path
+        android:pathData="M36,36m-34,0a34,34 0,1 1,68 0a34,34 0,1 1,-68 0"
+        android:strokeWidth="2"
+        android:strokeColor="#FFFFFF"/>
+</vector>

--- a/app/src/main/res/layout/activity_in_app_camera.xml
+++ b/app/src/main/res/layout/activity_in_app_camera.xml
@@ -18,6 +18,7 @@
         android:layout_marginBottom="50dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:src="@drawable/ic_shutter"
+        android:contentDescription="@string/capture_photo"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
@@ -30,6 +31,7 @@
         android:layout_marginEnd="16dp"
         android:background="?attr/selectableItemBackgroundBorderless"
         android:src="@android:drawable/ic_menu_close_clear_cancel"
+        android:contentDescription="@string/close_camera"
         app:tint="@android:color/white"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/activity_in_app_camera.xml
+++ b/app/src/main/res/layout/activity_in_app_camera.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/viewFinder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <ImageButton
+        android:id="@+id/image_capture_button"
+        android:layout_width="72dp"
+        android:layout_height="72dp"
+        android:layout_marginBottom="50dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@drawable/ic_shutter"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageButton
+        android:id="@+id/close_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:src="@android:drawable/ic_menu_close_clear_cancel"
+        app:tint="@android:color/white"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,4 +186,8 @@
         <item quantity="other">%d Chapters</item>
     </plurals>
     <string name="testpress_login_with_different_account">Login with different account</string>
+    <string name="capture_photo">Capture photo</string>
+    <string name="close_camera">Close camera</string>
+    <string name="camera_permission_denied">Camera permissions not granted by the user.</string>
+    <string name="image_creation_failed">Failed to create image file.</string>
 </resources>


### PR DESCRIPTION
#### What is the purpose of the change ? 

* Users on MDM-managed devices could not upload photos or files because the app launched external system camera and chooser intents restricted by device policy. (More info here on why we are doing this: testpress/testpress_python#12175)
* Selecting file or camera inputs in WebViews opened unnecessary system chooser dialogs instead of launching the requested input directly.
* SSO WebView navigation was restricted to a single hardcoded screen, preventing reusability across other web-based features like discussions.
* Camera capture now operates directly inside the app, file inputs launch the file manager directly, and SSO WebView redirects dynamically handle target routes.