### PR TITLE
fix: Update camerax to 1.4.0 to support 16KB page sizes on API 35+

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     implementation "androidx.exifinterface:exifinterface:1.3.6"
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 
-    def camerax_version = "1.3.1"
+    def camerax_version = "1.4.0"
     implementation "androidx.camera:camera-core:${camerax_version}"
     implementation "androidx.camera:camera-camera2:${camerax_version}"
     implementation "androidx.camera:camera-lifecycle:${camerax_version}"


### PR DESCRIPTION
- Older CameraX versions ship 4 KB-aligned native libraries, causing compatibility failures on Android 15+ devices requiring 16 KB pages.
- Upgrade CameraX to 1.4.0+ to use officially supported 16 KB-aligned native binaries.
- Perform a clean build to ensure stale 4 KB-aligned binaries are removed.
