### PR TITLE
build: Update minSdkVersion to 28 in app/build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -182,7 +182,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 26
+        minSdkVersion 28
         targetSdkVersion 36
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Update the minimum Android SDK version from 26 to 28, bumping the lowest supported Android version to Android 9 (Pie).