### PR TITLE
feat: Add Live Classes menu item and native content redirect

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -372,6 +372,7 @@ public class MainActivity extends TestpressFragmentActivity {
             menu.findItem(R.id.downloads).setVisible(false);
             menu.findItem(R.id.discussions).setVisible(false);
             menu.findItem(R.id.exam_results).setVisible(false);
+            menu.findItem(R.id.live_classes).setVisible(false);
         } else {
             menu.findItem(R.id.logout).setVisible(true);
             if (mInstituteSettings != null) {
@@ -383,6 +384,7 @@ public class MainActivity extends TestpressFragmentActivity {
             menu.findItem(R.id.downloads).setVisible(true);
             menu.findItem(R.id.login).setVisible(false);
             menu.findItem(R.id.exam_results).setVisible(true);
+            menu.findItem(R.id.live_classes).setVisible(true);
             if (mInstituteSettings != null) {
                 menu.findItem(R.id.discussions).setVisible(Boolean.TRUE.equals(mInstituteSettings.getForumEnabled()));
                 menu.findItem(R.id.student_report).setVisible(mInstituteSettings.isStudentReportEnabled());

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -31,12 +31,17 @@ import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
+import android.text.TextUtils;
+import java.util.List;
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import javax.inject.Inject;
+import in.testpress.core.TestpressSdk;
+import in.testpress.core.TestpressSession;
+import in.testpress.course.TestpressCourse;
 
 import in.testpress.testpress.BuildConfig;
 import in.testpress.testpress.TestpressApplication;
@@ -88,8 +93,8 @@ public class WebViewActivity extends BaseToolBarActivity {
                     }
                 }
             }
-            mUploadMessages.onReceiveValue(results);
-            mUploadMessages = null;
+                mUploadMessages.onReceiveValue(results);
+                mUploadMessages = null;
         } else {
 
             if (requestCode == FILE_CHOOSER_RESULT_CODE) {
@@ -177,6 +182,9 @@ public class WebViewActivity extends BaseToolBarActivity {
 
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                if (handleNativeContentDetailRedirect(url)) {
+                    return true;
+                }
                 if (allowExternalLink || isInstituteURL(url)) {
                     view.loadUrl(url);
                 } else {
@@ -271,6 +279,28 @@ public class WebViewActivity extends BaseToolBarActivity {
                 }
             }
         });
+    }
+
+    private boolean handleNativeContentDetailRedirect(String url) {
+        if (url == null) {
+            return false;
+        }
+        Uri uri = Uri.parse(url);
+        String path = uri.getPath();
+        if (path != null && (path.contains("/live-classes/") || path.contains("/events/live-classes") || path.contains("/contents/"))) {
+            List<String> segments = uri.getPathSegments();
+            if (segments != null && !segments.isEmpty()) {
+                String lastSegment = segments.get(segments.size() - 1);
+                if (TextUtils.isDigitsOnly(lastSegment)) {
+                    TestpressSession session = TestpressSdk.getTestpressSession(WebViewActivity.this);
+                    if (session != null) {
+                        TestpressCourse.showContentDetail(WebViewActivity.this, lastSegment, session);
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     private Boolean isInstituteURL(String url){

--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -101,6 +101,7 @@ public class HandleMainMenu {
             intent.putExtra(SSOWebViewRedirectActivity.EXTRA_NEXT_PATH, "/tickets/mobile/");
             activity.startActivity(intent);
         });
+        menuActions.put(R.id.live_classes, this::launchLiveClassesActivity);
         menuActions.put(R.id.offline_exam_list, this::launchOfflineExamListActivity);
         menuActions.put(R.id.discussions, () -> {
             String label = instituteSettings.getForumLabel();
@@ -259,6 +260,13 @@ public class HandleMainMenu {
         intent.putExtra(SSOWebViewRedirectActivity.EXTRA_TITLE, title);
         intent.putExtra(SSOWebViewRedirectActivity.EXTRA_NEXT_PATH, "/discussions/new");
         intent.putExtra(SSOWebViewRedirectActivity.EXTRA_ALLOW_EXTERNAL, true);
+        activity.startActivity(intent);
+    }
+
+    private void launchLiveClassesActivity() {
+        Intent intent = new Intent(activity, SSOWebViewRedirectActivity.class);
+        intent.putExtra(SSOWebViewRedirectActivity.EXTRA_TITLE, "Live Classes");
+        intent.putExtra(SSOWebViewRedirectActivity.EXTRA_NEXT_PATH, "/events/live-classes-list/?testpress_app=android");
         activity.startActivity(intent);
     }
 

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -41,6 +41,12 @@
             android:visible="false"
             app:showAsAction="never"/>
         <item
+            android:id="@+id/live_classes"
+            android:title="Live Classes"
+            android:icon="@drawable/testpress_live_conference_icon"
+            android:visible="false"
+            app:showAsAction="never"/>
+        <item
             android:id="@+id/offline_exam_list"
             android:title="Offline Exam"
             android:icon="@drawable/ic_exam"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
 
     <string name="all_posts">All Posts</string>
     <string name="all_discussions">All Discussions</string>
+    <string name="live_classes">Live Classes</string>
     <string name="categories">Categories</string>
     <string name="title_activity_reset_password_verification">ResetPasswordVerificationActivity
     </string>


### PR DESCRIPTION
- Add a "Live Classes" option to the main navigation menu launching the live classes page via SSO redirect
- Update MainActivity to show or hide the Live Classes menu item based on user login state
- Intercept live class and content URLs in WebViewActivity to open the native content detail screen
