### PR TITLE
ref: Extract Live Classes WebView logic to separate handler

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -84,6 +84,7 @@ import in.testpress.testpress.models.SsoUrl;
 import in.testpress.testpress.models.Update;
 import in.testpress.testpress.ui.fragments.DashboardFragment;
 import in.testpress.testpress.ui.utils.HandleMainMenu;
+import in.testpress.testpress.ui.utils.LiveClassesWebViewHandler;
 import in.testpress.testpress.util.AppChecker;
 import in.testpress.testpress.util.CommonUtils;
 import in.testpress.testpress.util.GCMPreference;
@@ -535,7 +536,7 @@ public class MainActivity extends TestpressFragmentActivity {
                 if (position < mMenuItemTitleIds.size() && mMenuItemTitleIds.get(position) == R.string.live_classes) {
                     Fragment fragment = mMenuItemFragments.get(position);
                     if (fragment instanceof WebViewFragment) {
-                        in.testpress.testpress.ui.utils.LiveClassesWebViewHandler.reload(
+                        LiveClassesWebViewHandler.reload(
                                 MainActivity.this,
                                 (WebViewFragment) fragment,
                                 serviceProvider
@@ -570,7 +571,7 @@ public class MainActivity extends TestpressFragmentActivity {
     }
 
     private void addLiveClassesWebViewFragment() {
-        in.testpress.testpress.ui.utils.LiveClassesWebViewHandler.addLiveClassesWebViewFragment(
+        LiveClassesWebViewHandler.addLiveClassesWebViewFragment(
                 this,
                 serviceProvider,
                 testpressService,

--- a/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/MainActivity.java
@@ -532,6 +532,16 @@ public class MainActivity extends TestpressFragmentActivity {
                     serviceProvider.logout(MainActivity.this, testpressService, serviceProvider,
                             logoutService);
                 }
+                if (position < mMenuItemTitleIds.size() && mMenuItemTitleIds.get(position) == R.string.live_classes) {
+                    Fragment fragment = mMenuItemFragments.get(position);
+                    if (fragment instanceof WebViewFragment) {
+                        in.testpress.testpress.ui.utils.LiveClassesWebViewHandler.reload(
+                                MainActivity.this,
+                                (WebViewFragment) fragment,
+                                serviceProvider
+                        );
+                    }
+                }
                 invalidateOptionsMenu();
             }
 
@@ -560,67 +570,12 @@ public class MainActivity extends TestpressFragmentActivity {
     }
 
     private void addLiveClassesWebViewFragment() {
-        final String initialUrl = BuildConfig.BASE_URL + "/events/live-classes-list/?testpress_app=android";
-        final WebViewFragment webViewFragment = new WebViewFragment();
-        final Bundle bundle = new Bundle();
-        bundle.putString(WebViewFragment.URL_TO_OPEN, initialUrl);
-        bundle.putBoolean(WebViewFragment.SHOW_LOADING_BETWEEN_PAGES, true);
-        bundle.putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, true);
-        bundle.putBoolean(WebViewFragment.ENABLE_SWIPE_REFRESH, true);
-        webViewFragment.setArguments(bundle);
-        webViewFragment.setListener(new WebViewFragment.Listener() {
-            @Override
-            public void onWebViewInitializationSuccess() {}
-
-            @Override
-            public boolean shouldOverrideUrlLoading(String url) {
-                if (url != null) {
-                    Uri uri = Uri.parse(url);
-                    String path = uri.getPath();
-                    if (path != null && (path.contains("/live-classes/") || path.contains("/events/live-classes") || path.contains("/contents/"))) {
-                        List<String> segments = uri.getPathSegments();
-                        if (segments != null && !segments.isEmpty()) {
-                            String lastSegment = segments.get(segments.size() - 1);
-                            if (TextUtils.isDigitsOnly(lastSegment)) {
-                                TestpressSession session = TestpressSdk.getTestpressSession(MainActivity.this);
-                                if (session != null) {
-                                    TestpressCourse.showContentDetail(MainActivity.this, lastSegment, session);
-                                    return true;
-                                }
-                            }
-                        }
-                    }
-                }
-                return false;
-            }
-
-            @Override
-            public void onPageStarted(String url) {}
-
-            @Override
-            public void onPageFinished(String url) {}
-        });
-
-        new SafeAsyncTask<SsoUrl>() {
-            @Override
-            public SsoUrl call() throws Exception {
-                return serviceProvider.getService(MainActivity.this).getSsoUrl();
-            }
-
-            @Override
-            protected void onSuccess(SsoUrl ssoUrl) throws Exception {
-                super.onSuccess(ssoUrl);
-                if (ssoUrl != null && ssoUrl.getSsoUrl() != null) {
-                    String fullSsoUrl = BuildConfig.WHITE_LABELED_HOST_URL + ssoUrl.getSsoUrl() + "&next=/events/live-classes-list/?testpress_app=android";
-                    bundle.putString(WebViewFragment.URL_TO_OPEN, fullSsoUrl);
-                    if (webViewFragment.getWebView() != null) {
-                        webViewFragment.getWebView().loadUrl(fullSsoUrl);
-                    }
-                }
-            }
-        }.execute();
-
-        addMenuItem(R.string.live_classes, R.drawable.ic_video_white, webViewFragment);
+        in.testpress.testpress.ui.utils.LiveClassesWebViewHandler.addLiveClassesWebViewFragment(
+                this,
+                serviceProvider,
+                testpressService,
+                logoutService
+        );
     }
 
     private void onItemSelected(int position) {

--- a/app/src/main/java/in/testpress/testpress/ui/utils/LiveClassesWebViewHandler.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/LiveClassesWebViewHandler.java
@@ -1,0 +1,155 @@
+package in.testpress.testpress.ui.utils;
+
+import android.os.Bundle;
+import android.net.Uri;
+import android.text.TextUtils;
+import java.util.List;
+
+import androidx.fragment.app.Fragment;
+
+import in.testpress.fragments.WebViewFragment;
+import in.testpress.core.TestpressSession;
+import in.testpress.core.TestpressSdk;
+import in.testpress.course.TestpressCourse;
+import in.testpress.testpress.BuildConfig;
+import in.testpress.testpress.R;
+import in.testpress.testpress.TestpressServiceProvider;
+import in.testpress.testpress.core.TestpressService;
+import in.testpress.testpress.authenticator.LogoutService;
+import in.testpress.testpress.models.SsoUrl;
+import in.testpress.testpress.ui.MainActivity;
+import in.testpress.testpress.util.SafeAsyncTask;
+
+public class LiveClassesWebViewHandler {
+
+    public static void addLiveClassesWebViewFragment(
+            final MainActivity activity,
+            final TestpressServiceProvider serviceProvider,
+            final TestpressService testpressService,
+            final LogoutService logoutService
+    ) {
+        final String initialUrl = BuildConfig.BASE_URL + "/events/live-classes-list/?testpress_app=android";
+        final WebViewFragment webViewFragment = new WebViewFragment();
+        final Bundle bundle = new Bundle();
+        bundle.putString(WebViewFragment.URL_TO_OPEN, initialUrl);
+        bundle.putBoolean(WebViewFragment.SHOW_LOADING_BETWEEN_PAGES, true);
+        bundle.putBoolean(WebViewFragment.IS_AUTHENTICATION_REQUIRED, true);
+        bundle.putBoolean(WebViewFragment.ENABLE_SWIPE_REFRESH, true);
+        bundle.putBoolean(WebViewFragment.ALLOW_NON_INSTITUTE_URL_IN_WEB_VIEW, true);
+        webViewFragment.setArguments(bundle);
+        webViewFragment.setListener(new WebViewFragment.Listener() {
+            @Override
+            public void onWebViewInitializationSuccess() {}
+
+            @Override
+            public boolean shouldOverrideUrlLoading(String url) {
+                if (url == null) return false;
+
+                Uri uri = Uri.parse(url);
+                String path = uri.getPath();
+
+                // Intercept native content detail pages (live class item detail)
+                if (path != null && (path.contains("/live-classes/") || path.contains("/events/live-classes") || path.contains("/contents/"))) {
+                    List<String> segments = uri.getPathSegments();
+                    if (segments != null && !segments.isEmpty()) {
+                        String lastSegment = segments.get(segments.size() - 1);
+                        if (TextUtils.isDigitsOnly(lastSegment) && !lastSegment.isEmpty()) {
+                            TestpressSession session = TestpressSdk.getTestpressSession(activity);
+                            if (session != null) {
+                                TestpressCourse.showContentDetail(activity, lastSegment, session);
+                                return true;
+                            }
+                        }
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public void onPageStarted(String url) {}
+
+            @Override
+            public void onPageFinished(String url) {}
+        });
+
+        new SafeAsyncTask<SsoUrl>() {
+            @Override
+            public SsoUrl call() throws Exception {
+                return serviceProvider.getService(activity).getSsoUrl();
+            }
+
+            @Override
+            protected void onSuccess(SsoUrl ssoUrl) throws Exception {
+                super.onSuccess(ssoUrl);
+                if (ssoUrl != null && ssoUrl.getSsoUrl() != null) {
+                    String fullSsoUrl = BuildConfig.WHITE_LABELED_HOST_URL + ssoUrl.getSsoUrl() + "&next=/events/live-classes-list/?testpress_app=android";
+                    bundle.putString(WebViewFragment.URL_TO_OPEN, fullSsoUrl);
+                    if (webViewFragment.isAdded() && webViewFragment.getWebView() != null) {
+                        webViewFragment.getWebView().loadUrl(fullSsoUrl);
+                    }
+                }
+            }
+
+            @Override
+            protected void onException(Exception e) throws RuntimeException {}
+        }.execute();
+
+        activity.addMenuItem(R.string.live_classes, R.drawable.ic_video_white, webViewFragment);
+    }
+
+    public static void reload(
+            final MainActivity activity,
+            final WebViewFragment webViewFragment,
+            final TestpressServiceProvider serviceProvider
+    ) {
+        if (webViewFragment.isAdded() && webViewFragment.getWebView() != null) {
+            String currentUrl = webViewFragment.getWebView().getUrl();
+            if (currentUrl != null && !currentUrl.isEmpty()) {
+                Uri uri = Uri.parse(currentUrl);
+                String host = uri.getHost();
+                String path = uri.getPath();
+                if (host != null && (BuildConfig.BASE_URL.contains(host) || BuildConfig.WHITE_LABELED_HOST_URL.contains(host))) {
+                    if (path != null && !path.contains("/login") && !path.contains("/logout")) {
+                        return;
+                    }
+                }
+            }
+        }
+
+        if (webViewFragment.isAdded()) {
+            webViewFragment.showLoading();
+        }
+
+        new SafeAsyncTask<SsoUrl>() {
+            @Override
+            public SsoUrl call() throws Exception {
+                return serviceProvider.getService(activity).getSsoUrl();
+            }
+
+            @Override
+            protected void onSuccess(SsoUrl ssoUrl) throws Exception {
+                super.onSuccess(ssoUrl);
+                if (ssoUrl != null && ssoUrl.getSsoUrl() != null) {
+                    String fullSsoUrl = BuildConfig.WHITE_LABELED_HOST_URL + ssoUrl.getSsoUrl() + "&next=/events/live-classes-list/?testpress_app=android";
+                    if (webViewFragment.getArguments() != null) {
+                        webViewFragment.getArguments().putString(WebViewFragment.URL_TO_OPEN, fullSsoUrl);
+                    }
+                    if (webViewFragment.isAdded() && webViewFragment.getWebView() != null) {
+                        webViewFragment.getWebView().loadUrl(fullSsoUrl);
+                    }
+                } else {
+                    if (webViewFragment.isAdded()) {
+                        webViewFragment.hideLoading();
+                    }
+                }
+            }
+
+            @Override
+            protected void onException(Exception e) throws RuntimeException {
+                if (webViewFragment.isAdded()) {
+                    webViewFragment.hideLoading();
+                }
+            }
+        }.execute();
+    }
+}

--- a/app/src/main/java/in/testpress/testpress/ui/utils/LiveClassesWebViewHandler.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/LiveClassesWebViewHandler.java
@@ -5,8 +5,6 @@ import android.net.Uri;
 import android.text.TextUtils;
 import java.util.List;
 
-import androidx.fragment.app.Fragment;
-
 import in.testpress.fragments.WebViewFragment;
 import in.testpress.core.TestpressSession;
 import in.testpress.core.TestpressSdk;
@@ -22,13 +20,15 @@ import in.testpress.testpress.util.SafeAsyncTask;
 
 public class LiveClassesWebViewHandler {
 
+    private static final String LIVE_CLASSES_PATH = "/events/live-classes-list/?testpress_app=android";
+
     public static void addLiveClassesWebViewFragment(
             final MainActivity activity,
             final TestpressServiceProvider serviceProvider,
             final TestpressService testpressService,
             final LogoutService logoutService
     ) {
-        final String initialUrl = BuildConfig.BASE_URL + "/events/live-classes-list/?testpress_app=android";
+        final String initialUrl = BuildConfig.BASE_URL + LIVE_CLASSES_PATH;
         final WebViewFragment webViewFragment = new WebViewFragment();
         final Bundle bundle = new Bundle();
         bundle.putString(WebViewFragment.URL_TO_OPEN, initialUrl);
@@ -72,27 +72,7 @@ public class LiveClassesWebViewHandler {
             public void onPageFinished(String url) {}
         });
 
-        new SafeAsyncTask<SsoUrl>() {
-            @Override
-            public SsoUrl call() throws Exception {
-                return serviceProvider.getService(activity).getSsoUrl();
-            }
-
-            @Override
-            protected void onSuccess(SsoUrl ssoUrl) throws Exception {
-                super.onSuccess(ssoUrl);
-                if (ssoUrl != null && ssoUrl.getSsoUrl() != null) {
-                    String fullSsoUrl = BuildConfig.WHITE_LABELED_HOST_URL + ssoUrl.getSsoUrl() + "&next=/events/live-classes-list/?testpress_app=android";
-                    bundle.putString(WebViewFragment.URL_TO_OPEN, fullSsoUrl);
-                    if (webViewFragment.isAdded() && webViewFragment.getWebView() != null) {
-                        webViewFragment.getWebView().loadUrl(fullSsoUrl);
-                    }
-                }
-            }
-
-            @Override
-            protected void onException(Exception e) throws RuntimeException {}
-        }.execute();
+        fetchSsoUrlAndLoad(activity, webViewFragment, serviceProvider, false);
 
         activity.addMenuItem(R.string.live_classes, R.drawable.ic_video_white, webViewFragment);
     }
@@ -108,7 +88,11 @@ public class LiveClassesWebViewHandler {
                 Uri uri = Uri.parse(currentUrl);
                 String host = uri.getHost();
                 String path = uri.getPath();
-                if (host != null && (BuildConfig.BASE_URL.contains(host) || BuildConfig.WHITE_LABELED_HOST_URL.contains(host))) {
+
+                String baseHost = Uri.parse(BuildConfig.BASE_URL).getHost();
+                String whiteLabelHost = Uri.parse(BuildConfig.WHITE_LABELED_HOST_URL).getHost();
+
+                if (host != null && (host.equals(baseHost) || host.equals(whiteLabelHost))) {
                     if (path != null && !path.contains("/login") && !path.contains("/logout")) {
                         return;
                     }
@@ -120,6 +104,15 @@ public class LiveClassesWebViewHandler {
             webViewFragment.showLoading();
         }
 
+        fetchSsoUrlAndLoad(activity, webViewFragment, serviceProvider, true);
+    }
+
+    private static void fetchSsoUrlAndLoad(
+            final MainActivity activity,
+            final WebViewFragment webViewFragment,
+            final TestpressServiceProvider serviceProvider,
+            final boolean showLoaderOnError
+    ) {
         new SafeAsyncTask<SsoUrl>() {
             @Override
             public SsoUrl call() throws Exception {
@@ -130,7 +123,7 @@ public class LiveClassesWebViewHandler {
             protected void onSuccess(SsoUrl ssoUrl) throws Exception {
                 super.onSuccess(ssoUrl);
                 if (ssoUrl != null && ssoUrl.getSsoUrl() != null) {
-                    String fullSsoUrl = BuildConfig.WHITE_LABELED_HOST_URL + ssoUrl.getSsoUrl() + "&next=/events/live-classes-list/?testpress_app=android";
+                    String fullSsoUrl = BuildConfig.WHITE_LABELED_HOST_URL + ssoUrl.getSsoUrl() + "&next=" + LIVE_CLASSES_PATH;
                     if (webViewFragment.getArguments() != null) {
                         webViewFragment.getArguments().putString(WebViewFragment.URL_TO_OPEN, fullSsoUrl);
                     }
@@ -138,7 +131,7 @@ public class LiveClassesWebViewHandler {
                         webViewFragment.getWebView().loadUrl(fullSsoUrl);
                     }
                 } else {
-                    if (webViewFragment.isAdded()) {
+                    if (showLoaderOnError && webViewFragment.isAdded()) {
                         webViewFragment.hideLoading();
                     }
                 }
@@ -146,7 +139,7 @@ public class LiveClassesWebViewHandler {
 
             @Override
             protected void onException(Exception e) throws RuntimeException {
-                if (webViewFragment.isAdded()) {
+                if (showLoaderOnError && webViewFragment.isAdded()) {
                     webViewFragment.hideLoading();
                 }
             }


### PR DESCRIPTION
- MainActivity previously contained inline setup and SSO retrieval logic for the Live Classes WebView fragment, complicating the main activity.
- Move the WebView setup, URL overriding, and SSO token loading into a dedicated LiveClassesWebViewHandler class.
- Add support for loading non-institute URLs and implement a reload method to fetch a new SSO token when the Live Classes menu item is selected.