### PR TITLE
feat: Disable sign up for xandylearning subdomain

### DIFF
--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -70,6 +70,7 @@ import in.testpress.testpress.events.UnAuthorizedErrorEvent;
 import in.testpress.testpress.models.DaoSession;
 import in.testpress.testpress.models.InstituteSettings;
 import in.testpress.testpress.models.InstituteSettingsDao;
+import in.testpress.testpress.util.AppChecker;
 import in.testpress.testpress.models.PostDao;
 import in.testpress.testpress.ui.DeviceNotAllowedActivity;
 import in.testpress.testpress.ui.MainActivity;
@@ -453,7 +454,7 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
         ViewUtils.setGone(socialLoginLayout, !instituteSettings.getFacebookLoginEnabled() &&
                 !instituteSettings.getGoogleLoginEnabled());
         boolean allowSignup = instituteSettings.getAllowSignup() != null && instituteSettings.getAllowSignup();
-        if (Arrays.asList(Constants.DISALLOWED_SIGNUP_SUBDOMAINS).contains(getString(R.string.testpress_site_subdomain))) {
+        if (AppChecker.INSTANCE.isSignupDisabledForSubdomain(this)) {
             allowSignup = false;
         }
         ViewUtils.setGone(signUpButton, !allowSignup);

--- a/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
+++ b/app/src/main/java/in/testpress/testpress/authenticator/LoginActivity.java
@@ -46,11 +46,13 @@ import com.squareup.otto.Subscribe;
 
 import java.io.IOException;
 import java.security.PublicKey;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
 import javax.inject.Inject;
+import in.testpress.testpress.core.Constants;
 import in.testpress.core.TestpressCallback;
 import in.testpress.core.TestpressException;
 import in.testpress.core.TestpressSDKDatabase;
@@ -450,7 +452,11 @@ public class LoginActivity extends ActionBarAccountAuthenticatorActivity {
         ViewUtils.setGone(googleLoginButton, !instituteSettings.getGoogleLoginEnabled());
         ViewUtils.setGone(socialLoginLayout, !instituteSettings.getFacebookLoginEnabled() &&
                 !instituteSettings.getGoogleLoginEnabled());
-        ViewUtils.setGone(signUpButton, !instituteSettings.getAllowSignup());
+        boolean allowSignup = instituteSettings.getAllowSignup() != null && instituteSettings.getAllowSignup();
+        if (Arrays.asList(Constants.DISALLOWED_SIGNUP_SUBDOMAINS).contains(getString(R.string.testpress_site_subdomain))) {
+            allowSignup = false;
+        }
+        ViewUtils.setGone(signUpButton, !allowSignup);
     }
 
 

--- a/app/src/main/java/in/testpress/testpress/core/Constants.java
+++ b/app/src/main/java/in/testpress/testpress/core/Constants.java
@@ -12,6 +12,8 @@ import static in.testpress.testpress.BuildConfig.BASE_URL;
 public final class Constants {
     private Constants() {}
 
+    public static final String[] DISALLOWED_SIGNUP_SUBDOMAINS = {"xandylearning"};
+
     public static final class Http {
         private Http() {}
 

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
@@ -16,6 +16,7 @@ import `in`.testpress.testpress.core.TestpressService
 import `in`.testpress.testpress.databinding.UsernameLoginLayoutBinding
 import `in`.testpress.testpress.models.InstituteSettings
 import `in`.testpress.testpress.ui.WebViewActivity
+import `in`.testpress.testpress.util.AppChecker
 import `in`.testpress.testpress.util.UIUtils
 import `in`.testpress.testpress.util.isEmpty
 import `in`.testpress.util.ViewUtils
@@ -188,7 +189,7 @@ class UsernameAuthentication : BaseAuthenticationFragment() {
     }
 
     private fun showOrHideButtons() {
-        if (!instituteSettings.allowSignup || Constants.DISALLOWED_SIGNUP_SUBDOMAINS.contains(getString(R.string.testpress_site_subdomain))) {
+        if (!instituteSettings.allowSignup || AppChecker.isSignupDisabledForSubdomain(requireContext())) {
             binding.signUp.visibility = View.GONE
         }
         ViewUtils.setGone(binding.phoneLogin, 3 !in instituteSettings.allowedLoginMethods)

--- a/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/fragments/UsernameAuthentication.kt
@@ -188,7 +188,7 @@ class UsernameAuthentication : BaseAuthenticationFragment() {
     }
 
     private fun showOrHideButtons() {
-        if (!instituteSettings.allowSignup) {
+        if (!instituteSettings.allowSignup || Constants.DISALLOWED_SIGNUP_SUBDOMAINS.contains(getString(R.string.testpress_site_subdomain))) {
             binding.signUp.visibility = View.GONE
         }
         ViewUtils.setGone(binding.phoneLogin, 3 !in instituteSettings.allowedLoginMethods)

--- a/app/src/main/java/in/testpress/testpress/util/AppChecker.kt
+++ b/app/src/main/java/in/testpress/testpress/util/AppChecker.kt
@@ -19,9 +19,6 @@ object AppChecker {
         return context.getString(R.string.testpress_site_subdomain) == "catking"
     }
 
-    /**
-     * Checks if signups should be disabled for the current subdomain (e.g., xandylearning).
-     */
     fun isSignupDisabledForSubdomain(context: Context): Boolean {
         return Constants.DISALLOWED_SIGNUP_SUBDOMAINS.contains(context.getString(R.string.testpress_site_subdomain))
     }

--- a/app/src/main/java/in/testpress/testpress/util/AppChecker.kt
+++ b/app/src/main/java/in/testpress/testpress/util/AppChecker.kt
@@ -1,7 +1,8 @@
 package `in`.testpress.testpress.util
 
-import `in`.testpress.testpress.R
 import android.content.Context
+import `in`.testpress.testpress.R
+import `in`.testpress.testpress.core.Constants
 import `in`.testpress.ui.WebViewWithSSOActivity
 
 object AppChecker {
@@ -16,5 +17,12 @@ object AppChecker {
 
     fun isCatkingApp(context: Context): Boolean {
         return context.getString(R.string.testpress_site_subdomain) == "catking"
+    }
+
+    /**
+     * Checks if signups should be disabled for the current subdomain (e.g., xandylearning).
+     */
+    fun isSignupDisabledForSubdomain(context: Context): Boolean {
+        return Constants.DISALLOWED_SIGNUP_SUBDOMAINS.contains(context.getString(R.string.testpress_site_subdomain))
     }
 }


### PR DESCRIPTION
- Added "xandylearning" to the list of disallowed subdomains for sign up in Constants
- Hide the sign up button in LoginActivity and UsernameAuthentication if
  the current subdomain matches the disallowed list


Todo -
https://app.basecamp.com/4160028/buckets/48341145/card_tables/cards/10235987664