### PR TITLE
fix: Hide web sidebar and header in Android WebViews

### DIFF
--- a/app/src/main/java/in/testpress/testpress/ui/SSOWebViewRedirectActivity.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/SSOWebViewRedirectActivity.kt
@@ -80,6 +80,7 @@ class SSOWebViewRedirectActivity: TestpressFragmentActivity(), EmptyViewListener
         if (!nextPath.contains("testpress_app=")) {
             nextPath = if (nextPath.contains("?")) "$nextPath&testpress_app=android" else "$nextPath?testpress_app=android"
         }
+        val encodedNextPath = android.net.Uri.encode(nextPath)
         val allowExternal = intent.getBooleanExtra(EXTRA_ALLOW_EXTERNAL, false)
         webviewIntent.putExtra(WebViewActivity.ACTIVITY_TITLE, title)
         webviewIntent.putExtra(WebViewActivity.ENABLE_BACK, true)
@@ -87,7 +88,7 @@ class SSOWebViewRedirectActivity: TestpressFragmentActivity(), EmptyViewListener
         webviewIntent.putExtra(WebViewActivity.ALLOW_EXTERNAL_LINK, allowExternal)
         webviewIntent.putExtra(
             WebViewActivity.URL_TO_OPEN,
-            BuildConfig.WHITE_LABELED_HOST_URL + ssoLink?.ssoUrl + "&next=" + nextPath
+            BuildConfig.WHITE_LABELED_HOST_URL + ssoLink?.ssoUrl + "&next=" + encodedNextPath
         )
         startActivity(webviewIntent)
         finish()

--- a/app/src/main/java/in/testpress/testpress/ui/SSOWebViewRedirectActivity.kt
+++ b/app/src/main/java/in/testpress/testpress/ui/SSOWebViewRedirectActivity.kt
@@ -76,7 +76,10 @@ class SSOWebViewRedirectActivity: TestpressFragmentActivity(), EmptyViewListener
         val webviewIntent = Intent(this@SSOWebViewRedirectActivity, WebViewActivity::class.java)
         webviewIntent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP;
         val title = intent.getStringExtra(EXTRA_TITLE) ?: "Doubts"
-        val nextPath = intent.getStringExtra(EXTRA_NEXT_PATH) ?: "/tickets/mobile/"
+        var nextPath = intent.getStringExtra(EXTRA_NEXT_PATH) ?: "/tickets/mobile/"
+        if (!nextPath.contains("testpress_app=")) {
+            nextPath = if (nextPath.contains("?")) "$nextPath&testpress_app=android" else "$nextPath?testpress_app=android"
+        }
         val allowExternal = intent.getBooleanExtra(EXTRA_ALLOW_EXTERNAL, false)
         webviewIntent.putExtra(WebViewActivity.ACTIVITY_TITLE, title)
         webviewIntent.putExtra(WebViewActivity.ENABLE_BACK, true)

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -151,6 +151,10 @@ public class WebViewActivity extends BaseToolBarActivity {
         WebSettings webSettings = webView.getSettings();
         webSettings.setJavaScriptEnabled(true);
         webSettings.setAllowFileAccess(true);
+        String userAgent = webSettings.getUserAgentString();
+        if (userAgent != null && !userAgent.contains("TestpressAndroidApp")) {
+            webSettings.setUserAgentString(userAgent + " TestpressAndroidApp/wv");
+        }
 
         if (Build.VERSION.SDK_INT >= 21) {
             webSettings.setMixedContentMode(0);
@@ -189,6 +193,7 @@ public class WebViewActivity extends BaseToolBarActivity {
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(webView, url);
                 pb_loading.setVisibility(View.GONE);
+                hideWebSidebar(view);
             }
         });
 
@@ -309,7 +314,27 @@ public class WebViewActivity extends BaseToolBarActivity {
     }
 
     public void setUrl(String url) {
+        if (url != null && isInstituteURL(url) && !url.contains("testpress_app=")) {
+            try {
+                Uri uri = Uri.parse(url);
+                url = uri.buildUpon().appendQueryParameter("testpress_app", "android").build().toString();
+            } catch (Exception e) {
+                // Ignore parsing errors and keep original url
+            }
+        }
         this.url = url;
+    }
+
+    private void hideWebSidebar(WebView view) {
+        String css = "header, aside, nav, .sidebar { display: none !important; } " +
+                     "main { padding-left: 0 !important; margin-top: 0 !important; }";
+        String js = "javascript:(function() { " +
+                    "var style = document.createElement('style'); " +
+                    "style.type = 'text/css'; " +
+                    "style.appendChild(document.createTextNode('" + css + "')); " +
+                    "document.head.appendChild(style); " +
+                    "})()";
+        view.loadUrl(js);
     }
 
 

--- a/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
+++ b/app/src/main/java/in/testpress/testpress/ui/WebViewActivity.java
@@ -182,7 +182,7 @@ public class WebViewActivity extends BaseToolBarActivity {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
                 if (allowExternalLink || isInstituteURL(url)) {
-                    view.loadUrl(url);
+                    view.loadUrl(appendAppQueryParam(url));
                 } else {
                     openInExternal(url);
                 }
@@ -193,7 +193,7 @@ public class WebViewActivity extends BaseToolBarActivity {
             public void onPageFinished(WebView view, String url) {
                 super.onPageFinished(webView, url);
                 pb_loading.setVisibility(View.GONE);
-                hideWebSidebar(view);
+                hideWebSidebar(view, url);
             }
         });
 
@@ -313,28 +313,38 @@ public class WebViewActivity extends BaseToolBarActivity {
         });
     }
 
-    public void setUrl(String url) {
+    public String appendAppQueryParam(String url) {
         if (url != null && isInstituteURL(url) && !url.contains("testpress_app=")) {
             try {
                 Uri uri = Uri.parse(url);
-                url = uri.buildUpon().appendQueryParameter("testpress_app", "android").build().toString();
+                return uri.buildUpon().appendQueryParameter("testpress_app", "android").build().toString();
             } catch (Exception e) {
-                // Ignore parsing errors and keep original url
+                Log.w(TAG, "Failed to append testpress_app parameter to url: " + url, e);
             }
         }
-        this.url = url;
+        return url;
     }
 
-    private void hideWebSidebar(WebView view) {
-        String css = "header, aside, nav, .sidebar { display: none !important; } " +
-                     "main { padding-left: 0 !important; margin-top: 0 !important; }";
-        String js = "javascript:(function() { " +
-                    "var style = document.createElement('style'); " +
-                    "style.type = 'text/css'; " +
-                    "style.appendChild(document.createTextNode('" + css + "')); " +
-                    "document.head.appendChild(style); " +
+    public void setUrl(String url) {
+        this.url = appendAppQueryParam(url);
+    }
+
+    private void hideWebSidebar(WebView view, String url) {
+        if (url == null || !isInstituteURL(url)) {
+            return;
+        }
+        String js = "(function() { " +
+                    "   var css = '@media (min-width: 1024px) { header, aside, nav, .sidebar { display: none !important; } main { padding-left: 0 !important; margin-top: 0 !important; } }';" +
+                    "   var style = document.createElement('style'); " +
+                    "   style.type = 'text/css'; " +
+                    "   style.appendChild(document.createTextNode(css)); " +
+                    "   document.head.appendChild(style); " +
                     "})()";
-        view.loadUrl(js);
+        if (Build.VERSION.SDK_INT >= 19) {
+            view.evaluateJavascript(js, null);
+        } else {
+            view.loadUrl("javascript:" + js);
+        }
     }
 
 

--- a/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
+++ b/app/src/main/java/in/testpress/testpress/ui/utils/HandleMainMenu.java
@@ -90,7 +90,7 @@ public class HandleMainMenu {
         menuActions.put(R.id.doubts, () -> {
             Intent intent = new Intent(activity, SSOWebViewRedirectActivity.class);
             intent.putExtra(SSOWebViewRedirectActivity.EXTRA_TITLE, "Doubts");
-            intent.putExtra(SSOWebViewRedirectActivity.EXTRA_NEXT_PATH, "/tickets/mobile/");
+            intent.putExtra(SSOWebViewRedirectActivity.EXTRA_NEXT_PATH, "/tickets/mobile/?testpress_app=android");
             activity.startActivity(intent);
         });
         menuActions.put(R.id.offline_exam_list, this::launchOfflineExamListActivity);
@@ -230,7 +230,7 @@ public class HandleMainMenu {
     private void launchDiscussionActivity(String title) {
         Intent intent = new Intent(activity, SSOWebViewRedirectActivity.class);
         intent.putExtra(SSOWebViewRedirectActivity.EXTRA_TITLE, title);
-        intent.putExtra(SSOWebViewRedirectActivity.EXTRA_NEXT_PATH, "/discussions/new");
+        intent.putExtra(SSOWebViewRedirectActivity.EXTRA_NEXT_PATH, "/discussions/new?testpress_app=android");
         intent.putExtra(SSOWebViewRedirectActivity.EXTRA_ALLOW_EXTERNAL, true);
         activity.startActivity(intent);
     }


### PR DESCRIPTION
- **Issue**: On tablets or when rotating to landscape mode, embedded web pages (such as Forum and Doubts) displayed the full web sidebar and top header navigation, granting users full access to external web app navigation inside the Android app.
- **Cause**: Tailwind CSS responsive breakpoints (>=1024px) rendered the desktop sidebar because backend Django templates failed to detect the device as an in-app WebView (user_agent.is_webview evaluated to false on tablets and testpress_app query parameter was missing).
- **Fix**:
  - Appended testpress_app=android to default next paths in HandleMainMenu and SSOWebViewRedirectActivity.
  - Automatically attached testpress_app=android query parameter to institute URLs in WebViewActivity.
  - Updated WebView User-Agent to include TestpressAndroidApp/wv token.
  - Injected CSS in onPageFinished as a client-side safety net to force-hide headers and sidebars on large viewports.


Basecamp todo:
https://app.basecamp.com/4160028/buckets/48707509/card_tables/cards/10278107873#__recording_10278498934